### PR TITLE
update the readme to reference Calculinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Make sure you have the following installed on your build host:
 1. **Clone this repository**:
    ```bash
    mkdir calculinux-build && cd calculinux-build
-   git clone https://github.com/0xd61/meta-picocalc.git meta-calculinux
+   git clone https://github.com/calculinux/meta-calculinux.git meta-calculinux
    ```
 
-2. **Build Calculinux with KAS**:
+2. **Build Calculinux for Luckfox Lyra with KAS**:
    ```bash
    ./meta-calculinux/kas-container --ssh-dir ~/.ssh build --update meta-calculinux/kas-luckfox-lyra-bundle.yaml
    ```


### PR DESCRIPTION
This pull request updates the `README.md` to rebrand the project from "meta-picocalc-luckfox" to "meta-calculinux".

**Project Rebranding and Documentation Updates:**

* Updated all references from `meta-picocalc` and "picocalc-buildsystem" to `meta-calculinux` and "calculinux-build" throughout the documentation to reflect the new project name and directory structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R68) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R77) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R115)
* Added an expanded project overview section describing Calculinux, its hardware focus, and distribution goals.
* Revised the features list to emphasize Calculinux's hardware support, read-only root filesystem, OTA update capabilities, and extensibility.

**Improved Build and Usage Instructions:**

* Updated build and installation steps to use the new `meta-calculinux` directory and clarified the process for building and installing Calculinux images. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R77) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R115)
* Improved the explanation of the RAUC OTA update process, specifically mentioning Calculinux and clarifying the dual rootfs setup for robust rollbacks.