### PR TITLE
Change to use mmcblk0p6 for overlayfs and auto expand partition

### DIFF
--- a/meta-picocalc-bsp-rockchip/conf/machine/luckfox-lyra.conf
+++ b/meta-picocalc-bsp-rockchip/conf/machine/luckfox-lyra.conf
@@ -18,8 +18,13 @@ RAUC_COMPATIBLE = "picocalc-luckfox-lyra"
 KERNEL_DEVICETREE = "rk3506g-luckfox-lyra.dtb"
 UBOOT_MACHINE = "rk3506_luckfox_defconfig"
 
+#Choose which partition to use for Overlay FS
+# Picocalc SD card Partition 1
+#OVERLAYFS_ETC_DEVICE = "/dev/mmcblk1p1"
+# Luckfox Lyra MicroSD card Partition 6
+OVERLAYFS_ETC_DEVICE = "/dev/mmcblk0p6"
+
 OVERLAYFS_ETC_USE_ORIG_INIT_NAME = "0"
-OVERLAYFS_ETC_DEVICE = "/dev/mmcblk1p1"
 OVERLAYFS_ETC_MOUNT_POINT = "/data"
 OVERLAYFS_ETC_FSTYPE ?= "ext4"
 

--- a/meta-picocalc-bsp-rockchip/wic/luckfox-lyra.wks.in
+++ b/meta-picocalc-bsp-rockchip/wic/luckfox-lyra.wks.in
@@ -10,3 +10,4 @@ part --source empty --part-name ubootenv --size=1 --align=4
 part / --source rootfs --fstype ${RK_ROOTFS_TYPE} --label ROOT_A --mkfs-extraopts "${RK_ROOTFS_EXTRAOPTS}" --align 8192 --fixed-size 2048
 part / --source rootfs --fstype ${RK_ROOTFS_TYPE} --label ROOT_B --mkfs-extraopts "${RK_ROOTFS_EXTRAOPTS}" --align 8192 --fixed-size 2048
 part swap --size 44 --label swap --fstype=swap --size=1024M --overhead-factor 1
+part --label data --source empty --fstype ext4 --fixed-size 2048 --align 8192

--- a/meta-picocalc-distro/files/overlayfs-etc-preinit.sh.in
+++ b/meta-picocalc-distro/files/overlayfs-etc-preinit.sh.in
@@ -17,6 +17,16 @@ mount -t sysfs sysfs /sys
 
 OVERLAYS="/etc /root /home /var"
 
+#Grow the overlay partition to fill disk
+PARTITION_SYSFS_PATH="/sys/class/block/$(basename "{OVERLAYFS_ETC_DEVICE}")"
+PARTITION_DISK="/dev/$(basename $(readlink -f "$PARTITION_SYSFS_PATH/.."))"
+PARTITION_NUM="$(cat "$PARTITION_SYSFS_PATH/partition")"
+
+if growpart --free-percent=10 "$PARTITION_DISK" $PARTITION_NUM; then
+  e2fsck -y -f {OVERLAYFS_ETC_DEVICE}
+  resize2fs {OVERLAYFS_ETC_DEVICE}
+fi
+
 mkdir -p {OVERLAYFS_ETC_MOUNT_POINT}
 if mount -n -t {OVERLAYFS_ETC_FSTYPE} \
     -o {OVERLAYFS_ETC_MOUNT_OPTIONS} \

--- a/meta-picocalc-distro/recipes-core/cloud-utils/cloud-utils-growpart_git.bb
+++ b/meta-picocalc-distro/recipes-core/cloud-utils/cloud-utils-growpart_git.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "growpart utility from cloud-utils"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
+
+SRC_URI = "git://github.com/canonical/cloud-utils.git;protocol=https;branch=main;nobranch=1"
+SRCREV = "49e5dd7849ee3c662f3db35e857148d02e72694b"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${base_sbindir}
+    install -m 0755 ${S}/bin/growpart ${D}${base_sbindir}
+}
+
+FILES:${PN} += "${base_sbindir}/growpart"
+
+BBCLASSEXTEND = "native"

--- a/meta-picocalc-distro/recipes-core/image/picocalc-image.bb
+++ b/meta-picocalc-distro/recipes-core/image/picocalc-image.bb
@@ -25,7 +25,9 @@ IMAGE_INSTALL += " \
     autoconf \
     bash \
     busybox \
+    cloud-utils-growpart \
     curl \
+    e2fsprogs-resize2fs \
     file \
     gdb \
     git \


### PR DESCRIPTION
Courtesy of @johnlaur

This pull request introduces improvements to the Luckfox Lyra device's overlay filesystem setup, focusing on automating partition resizing and ensuring the necessary utilities are available in the image. The main changes include switching the overlay partition, adding a data partition, automating partition growth during pre-init, and including required utilities in the build.

**Overlay partition and filesystem setup:**

* Changed the overlay filesystem device for Luckfox Lyra to `/dev/mmcblk0p6`, and updated configuration comments for clarity.
* Added a new `data` partition to the Luckfox Lyra disk image (`luckfox-lyra.wks.in`) to support overlay and data storage.

**Automated partition resizing:**

* Updated the overlayfs pre-init script to automatically grow the overlay partition using `growpart` and `resize2fs`, ensuring it fills available disk space before mounting.

**Image and utility support:**

* Added the `cloud-utils-growpart` and `e2fsprogs-resize2fs` utilities to the image build to support automated partition resizing.
* Introduced a recipe for building and installing the `growpart` utility from `cloud-utils`, making it available during image creation.