### PR TITLE
fiq serial interface and console at 115200

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/rk3506-luckfox-lyra.dtsi
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/rk3506-luckfox-lyra.dtsi
@@ -69,7 +69,7 @@
 		rockchip,serial-id = <0>;
 		rockchip,wake-irq = <0>;
 		rockchip,irq-mode-enable = <1>;
-		rockchip,baudrate = <1500000>;	/* Only 115200 and 1500000 */
+		rockchip,baudrate = <115200>;	/* Only 115200 and 1500000 */
 		interrupts = <GIC_SPI 115 IRQ_TYPE_LEVEL_HIGH>;
 	};
 


### PR DESCRIPTION
New PR for this commit. This changes the baud rate for the serial port connected through the picocalc to the rs232 USB converter in the top USB-C port to operate at a rate of 115200 when the kernel is running.

u-boot is still at 1500000 baud, and I do not consider this PR complete until u-boot is included in the change set.