### PR TITLE
publish images to the web server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,8 @@ jobs:
           echo "subfolder=continuous" >> $GITHUB_OUTPUT
           echo "is_prerelease=false" >> $GITHUB_OUTPUT
           echo "is_tagged_release=false" >> $GITHUB_OUTPUT
-        else
-          # Tagged releases - assume from main branch, use distro codename
+        elif [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+          # Tagged releases - check if this is actually a tag
           DISTRO_CODENAME=$(./kas-container shell ${{ matrix.kas_file }} -c "bitbake -e | grep '^DISTRO_CODENAME=' | cut -d'\"' -f2")
           echo "feed_name=${DISTRO_CODENAME}" >> $GITHUB_OUTPUT
           echo "subfolder=release" >> $GITHUB_OUTPUT
@@ -102,6 +102,12 @@ jobs:
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
           fi
           echo "is_tagged_release=true" >> $GITHUB_OUTPUT
+        else
+          # Pull requests or other refs - don't publish
+          echo "feed_name=${DISTRO_CODENAME}" >> $GITHUB_OUTPUT
+          echo "subfolder=branch" >> $GITHUB_OUTPUT
+          echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          echo "is_tagged_release=false" >> $GITHUB_OUTPUT
         fi
         
         echo "Feed configuration complete"


### PR DESCRIPTION
This pull request updates the build workflow to improve artifact publishing and feed configuration for Yocto builds. The main changes ensure that build artifacts are organized and published to the correct directories based on branch or tag, and add checks for required storage locations.

**Artifact publishing and storage improvements:**

* Added `OPKG_REPO_DIR` environment variable to define the package repository storage location for build artifacts.
* Added a check to verify that the package repository storage exists at `/mnt/opkg-repo` before proceeding with the build. The workflow will fail with a clear error message if the directory is missing.

**Feed configuration and artifact organization:**

* Introduced a new step to dynamically determine the feed name and subfolder for publishing artifacts, based on the branch or tag being built. This step uses the Yocto distro codename for stable and tagged releases, and "develop" for development builds.
* Added a step to publish build artifacts (RAUC bundles and WIC images) to webserver directories organized by feed name and subfolder. The workflow creates target directories and copies the relevant files, providing clear logging for published artifacts.