### PR TITLE
Update device references to by-partlabel for swap and RAUC devices

### DIFF
--- a/meta-calculinux-distro/recipes-core/base-files/files/fstab
+++ b/meta-calculinux-distro/recipes-core/base-files/files/fstab
@@ -5,4 +5,4 @@ proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
 tmpfs                /var/volatile        tmpfs      defaults              0  0
-/dev/disk/by-label/SWAP       none                 swap       sw                    0  0
+/dev/disk/by-partlabel/SWAP       none                 swap       sw                    0  0

--- a/meta-picocalc-bsp-rockchip/conf/machine/luckfox-lyra.conf
+++ b/meta-picocalc-bsp-rockchip/conf/machine/luckfox-lyra.conf
@@ -9,8 +9,8 @@ MACHINEOVERRIDES .= ":rockchip-rk3506-evb"
 
 WKS_FILE = "luckfox-lyra.wks.in"
 
-RAUC_SLOT_A_DEVICE = "/dev/disk/by-label/ROOT_A"
-RAUC_SLOT_B_DEVICE = "/dev/disk/by-label/ROOT_B"
+RAUC_SLOT_A_DEVICE = "/dev/disk/by-partlabel/ROOT_A"
+RAUC_SLOT_B_DEVICE = "/dev/disk/by-partlabel/ROOT_B"
 RAUC_COMPATIBLE = "calculinux-luckfox-lyra"
 
 KERNEL_DEVICETREE = "rk3506g-luckfox-lyra.dtb"


### PR DESCRIPTION
Change device references in fstab and configuration files to use by-partlabel, resolving an issue with RAUC not identifying root devices after an upgrade.