### PR TITLE
decrease the size of uploaded artifacts dramatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,10 @@ jobs:
           find "$DEPLOY_DIR" -name "*.raucb" | \
             xargs -I {} cp {} artifacts/ || true
           
+          # Copy u-boot files
+          cp "$DEPLOY_DIR/uboot-${{ matrix.machine }}-*.bin" artifacts/ || true
+          cp "$DEPLOY_DIR/u-boot-*initial-env-${{ matrix.machine }}-*" artifacts/ || true
+          
           # Copy other important files
           find "$DEPLOY_DIR" -name "*.manifest" -o -name "*.testdata.json" | \
             xargs -I {} cp {} artifacts/ || true
@@ -496,6 +500,8 @@ jobs:
         path: |
           artifacts/calculinux-bundle-${{ matrix.machine }}-*.raucb
           artifacts/calculinux-image-${{ matrix.machine }}.rootfs-*.wic.gz
+          artifacts/uboot-${{ matrix.machine }}-*.bin
+          artifacts/u-boot-*initial-env-${{ matrix.machine }}-*
         retention-days: 30
 
     - name: Create release


### PR DESCRIPTION
Archived builds tend to be very large because they contain two copies of each image, as well as unzipped versions as well. this is rediculous and nobody wants to download all of that.