### PR TITLE
Consider changing the friendly name of the distribution

### DIFF
--- a/meta-calculinux-distro/conf/distro/calculinux-distro.conf
+++ b/meta-calculinux-distro/conf/distro/calculinux-distro.conf
@@ -2,7 +2,7 @@ require conf/distro/poky.conf
 require conf/distro/include/gcsections.inc
 
 DISTRO = "calculinux-distro"
-DISTRO_NAME = "Calculinux (Linux distribution for Picocalc devices)"
+DISTRO_NAME = "Calculinux PicoCalc Edition"
 DISTROOVERRIDES = "poky:calculinux-distro"
 TCLIBC = "musl"
 


### PR DESCRIPTION
This is just a proposal for something a little less verbose

### Calculinux PicoCalc Edition

Having [Lyra] identified is probably wise too if the plan is to support other boards with nominally the same build