### PR TITLE
Change kernel and uboot git repositories to internal Calculinux versions

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/u-boot-rockchip.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/u-boot-rockchip.bbappend
@@ -11,7 +11,7 @@ EXTRA_OEMAKE += " KCFLAGS='-Wno-enum-int-mismatch -Wno-maybe-uninitialized'"
 
 SRCREV = "c1758ed5fecd6200db4e211524be2a0b762670b9"
 SRC_URI = " \
-    git://github.com/0xd61/luckfox-u-boot-2017.09-rk3506.git;nobranch=1;protocol=https \
+    git://github.com/Calculinux/luckfox-u-boot-2017.09-rk3506.git;nobranch=1;protocol=https \
     git://github.com/rockchip-linux/rkbin.git;protocol=https;nobranch=1;name=rkbin;destsuffix=rkbin; \
     file://backport-part-command-from-u-boot-2020.01.patch \
     file://backport-setexpr-fmt-from-u-boot-2021.10.patch \

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 SRCREV = "e0846929f1a797988a6965268f391fdb779becfc"
 
 SRC_URI = " \
-    git://github.com/0xd61/luckfox-linux-6.1-rk3506.git;protocol=https;nobranch=1 \
+    git://github.com/Calculinux/luckfox-linux-6.1-rk3506.git;protocol=https;nobranch=1 \
     file://rk3506-luckfox-lyra.dtsi;subdir=git/arch/${ARCH}/boot/dts/ \
     file://rk3506g-luckfox-lyra.dts;subdir=git/arch/${ARCH}/boot/dts/ \
     file://base-configs.cfg \


### PR DESCRIPTION
Update the source URIs for both the kernel and uboot to point to the internal Calculinux repositories.