### PR TITLE
Load the bootscript from the active partition

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/files/boot.scr.sh.in
+++ b/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/files/boot.scr.sh.in
@@ -13,38 +13,30 @@ setenv rauc_slot;
 if test "${{BOOT_ORDER}}" = "A"; then
     echo "Found only slot A, booting....";
     setenv rauc_slot "A";
-    part number mmc 0 ROOT_A mmcpart_hex;
 elif test "${{BOOT_ORDER}}" = "B"; then
     echo "Found only slot B, booting.... ";
     setenv rauc_slot "B";
-    part number mmc 0 ROOT_B mmcpart_hex;
 elif test "${{BOOT_ORDER}}" = "A B"; then
     if test ${{BOOT_A_LEFT}} -gt 0; then
         echo "Found valid slot A, ${{BOOT_A_LEFT}} attempts remaining";
         setexpr BOOT_A_LEFT ${{BOOT_A_LEFT}} - 1;
         setenv rauc_slot "A";
-        part number mmc 0 ROOT_A mmcpart_hex;
     else
         echo "Found slot B, booting.... ";
         setenv BOOT_ORDER "B";
         setenv rauc_slot "B";
-        part number mmc 0 ROOT_B mmcpart_hex;
     fi;
 elif test "${{BOOT_ORDER}}" = "B A"; then
     if test ${{BOOT_B_LEFT}} -gt 0; then
         echo "Found valid slot B, ${{BOOT_B_LEFT}} attempts remaining";
         setexpr BOOT_B_LEFT ${{BOOT_B_LEFT}} - 1;
         setenv rauc_slot "B";
-        part number mmc 0 ROOT_B mmcpart_hex;
     else
         echo "Found slot A, booting.... ";
         setenv BOOT_ORDER "A";
         setenv rauc_slot "A";
-        part number mmc 0 ROOT_A mmcpart_hex;
     fi;
 fi;
-
-setexpr mmcpart fmt %d $mmcpart_hex;
 
 if test -n "${{rauc_slot}}"; then
     echo "Saving Environment from bootcmd";
@@ -56,8 +48,9 @@ else
     reset;
 fi;
 
-setenv distro_bootpart "${{mmcpart}}"
-setenv bootcmd "run mmc_boot;"
+part number ${{devtype}} ${{devnum}} ROOT_${{rauc_slot}} mmcpart_hex;
+setexpr mmcpart fmt %d ${{mmcpart_hex}};
+
 saveenv;
 saveenv;
 

--- a/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/files/rk3506_common.h
+++ b/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/files/rk3506_common.h
@@ -83,16 +83,21 @@
 #include <config_distro_bootcmd.h>
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	ENV_MEM_LAYOUT_SETTINGS \
-	"partitions=" PARTS_RKIMG \
-	"distro_bootpart=3\0" \
-	ROCKCHIP_DEVICE_SETTINGS \
-	RKIMG_DET_BOOTDEV \
+	ENV_MEM_LAYOUT_SETTINGS												\
+	"partitions=" PARTS_RKIMG											\
+	"calculinux_bootcmd="												\
+ 	"env exists BOOT_ORDER || setenv BOOT_ORDER A B; "						\
+	"for boot_part_letter in ${BOOT_ORDER}; do "						\
+	    "part number ${devtype} ${devnum} ROOT_${boot_part_letter} distro_bootpart_hex; " \
+	    "setexpr distro_bootpart fmt %d ${distro_bootpart_hex}; " \
+	    "run scan_dev_for_boot; "								  \
+	"done\0"												  \
+	ROCKCHIP_DEVICE_SETTINGS								  \
+	RKIMG_DET_BOOTDEV										  \
 	BOOTENV
 
 #undef RKIMG_BOOTCOMMAND
-#define RKIMG_BOOTCOMMAND		\
-	"run mmc_boot;"
-
+#define RKIMG_BOOTCOMMAND								\
+	"run rkimg_bootdev; run calculinux_bootcmd;"
 #endif
 #endif


### PR DESCRIPTION
We now use the correct boot order provided by rauc to load the boot.scr.

If it fails to load, it will fallback to the other partition.

Unfortunately this change needs a reflash of the u-boot. To do this you can copy the `uboot.img` and `boot.scr` onto the board and flash the bootloadter onto the first partition with `sudo dd if=uboot.img of=/dev/mmcblk0p1`.

Afterwards replace the boot script in the `/boot/` directory (make sure to remount the rootfs read/write with `mount -o remount,rw /`).

Connect your board via USB to your computer and connect to the serial console with ` sudo picocom -b 1500000 /dev/ttyUSB0`.

Afterwards reboot your board and abort the autoboot with CTRL+C. Then reset the default environment inside the u-boot console and boot with
```
env default -f -a
saveenv
run bootcmd
```

This solves #47 
