### PR TITLE
Add rtl8188fu driver to EXTRA_WIFI_DRIVERS and remove from IMAGE_INSTALL

### DIFF
--- a/kas-luckfox-lyra-bundle.yaml
+++ b/kas-luckfox-lyra-bundle.yaml
@@ -47,6 +47,7 @@ local_conf_header:
     
     EXTRA_WIFI_DRIVERS = "\
       aic8800 \
+      rtl8188fu \
       rtl8723du \
       rtl8812au \
       rtl8814au \

--- a/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
+++ b/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
@@ -38,7 +38,6 @@ IMAGE_INSTALL += " \
     iw \
     iwd \
     kbd-keymaps \
-    kernel-module-rtl8188fu \
     kernel-modules \
     links \
     man-db \
@@ -50,7 +49,6 @@ IMAGE_INSTALL += " \
     overlayfs-tools \
     packagegroup-core-buildessential \
     rauc \
-    rtl8188fu \
     shadow \
     sudo \
     systemd-analyze \


### PR DESCRIPTION
This pull request updates the handling of the `rtl8188fu` Wi-Fi driver in the build configuration. The main change is moving the inclusion of this driver from the image installation list to the `EXTRA_WIFI_DRIVERS` variable, which likely streamlines driver management and avoids redundancy.

Driver management updates:

* Added `rtl8188fu` to the `EXTRA_WIFI_DRIVERS` variable in `kas-luckfox-lyra-bundle.yaml`, centralizing its configuration with other Wi-Fi drivers.
* Removed both `kernel-module-rtl8188fu` and `rtl8188fu` from the `IMAGE_INSTALL` list in `calculinux-image.bb`, preventing duplicate or unnecessary installation of this driver. [[1]](diffhunk://#diff-4bd946815d9e7ee906692e3db312de088bc4910a36de2b9986f555855272d7c3L41) [[2]](diffhunk://#diff-4bd946815d9e7ee906692e3db312de088bc4910a36de2b9986f555855272d7c3L53)