### PR TITLE
Install kernel config into /usr/share/kernel

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -58,4 +58,4 @@ do_install:append() {
     install -D -m 0644  "${B}/.config.gz" "${D}${datadir}/kernel/config.gz"
 }
 
-FILES:${KERNEL_PACKAGE_NAME} += "${datadir}/kernel"
+FILES:${KERNEL_PACKAGE_NAME}-base += "${datadir}/kernel"


### PR DESCRIPTION
This PR should install the current kernel config into /usr/share/kernel/config.gz.

This is not properly tested yet, since I currently don't have a functioning device. @benklop could you check if it works? I only checked on the install directory, if the file exists.