### PR TITLE
Add filesystem configuration support for EXT4, VFAT, and BTRFS

### DIFF
--- a/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
+++ b/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
@@ -25,9 +25,12 @@ IMAGE_INSTALL += " \
     android-tools \
     autoconf \
     bash \
+    btrfs-tools \
     busybox \
     cloud-utils-growpart \
     curl \
+    dosfstools \
+    e2fsprogs \
     e2fsprogs-resize2fs \
     file \
     gdb \

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/filesystems.cfg
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/filesystems.cfg
@@ -1,0 +1,33 @@
+# Filesystem configurations with extended attribute support
+
+# EXT2/EXT3/EXT4 filesystems
+CONFIG_EXT4_FS=y
+CONFIG_EXT4_USE_FOR_EXT2=y
+CONFIG_EXT4_FS_POSIX_ACL=y
+CONFIG_EXT4_FS_SECURITY=y
+CONFIG_EXT4_FS_ENCRYPTION=y
+# CONFIG_EXT4_DEBUG is not set
+
+# VFAT filesystem
+CONFIG_VFAT_FS=y
+CONFIG_FAT_DEFAULT_CODEPAGE=437
+CONFIG_FAT_DEFAULT_IOCHARSET="iso8859-1"
+
+# BTRFS filesystem
+CONFIG_BTRFS_FS=y
+CONFIG_BTRFS_FS_POSIX_ACL=y
+# CONFIG_BTRFS_FS_CHECK_INTEGRITY is not set
+# CONFIG_BTRFS_FS_RUN_SANITY_TESTS is not set
+# CONFIG_BTRFS_DEBUG is not set
+# CONFIG_BTRFS_ASSERT is not set
+# CONFIG_BTRFS_FS_REF_VERIFY is not set
+
+# Extended attribute support (should already be set in base-configs.cfg but include for completeness)
+CONFIG_FS_POSIX_ACL=y
+
+# Additional filesystem features
+CONFIG_EXPORTFS=y
+CONFIG_EXPORTFS_BLOCK_OPS=y
+CONFIG_FILE_LOCKING=y
+CONFIG_MANDATORY_FILE_LOCKING=y
+CONFIG_FS_ENCRYPTION=y

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -17,6 +17,7 @@ SRC_URI = " \
     file://led.cfg \
     file://removed.cfg \
     file://utf8.cfg \
+    file://filesystems.cfg \
     file://mmc-spi-fix-nullpointer-on-shutdown.patch \
 "
 
@@ -30,6 +31,7 @@ KERNEL_CONFIG_FRAGMENTS += " \
     led.cfg \
     removed.cfg \
     utf8.cfg \
+    filesystems.cfg \
 "
 
 KBUILD_DEFCONFIG = "rk3506_luckfox_defconfig"


### PR DESCRIPTION
Introduce mkfs and fscp tools for EXT4, VFAT, and BTRFS filesystems, including necessary kernel configurations and dependencies. Add   xattrs support for overlayfs to use.