### PR TITLE
Fix duplicate swap fstab entry causing boot timeout

### DIFF
--- a/meta-picocalc-bsp-rockchip/conf/machine/luckfox-lyra.conf
+++ b/meta-picocalc-bsp-rockchip/conf/machine/luckfox-lyra.conf
@@ -9,6 +9,11 @@ MACHINEOVERRIDES .= ":rockchip-rk3506-evb"
 
 WKS_FILE = "luckfox-lyra.wks.in"
 
+# /etc/fstab is managed in meta-calculinux-distro (PARTLABEL=SWAP, etc.).
+# Without this, wic appends generic /dev/sdaN swap entries during image
+# creation, causing ~90s boot delays when those devices do not exist.
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+
 RAUC_SLOT_A_DEVICE = "/dev/disk/by-partlabel/ROOT_A"
 RAUC_SLOT_B_DEVICE = "/dev/disk/by-partlabel/ROOT_B"
 RAUC_COMPATIBLE = "calculinux-luckfox-lyra"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Boot logs show swap being activated twice:

1. `PARTLABEL=SWAP` — found and activated correctly as `mmcblk0p5`
2. `/dev/sda5` — waited ~90s, then failed (no `sda` device on PicoCalc hardware)

The source fstab in `meta-calculinux-distro` is correct and only contains the `PARTLABEL=SWAP` entry. However, the WIC-built image also contained:

```
/dev/sda5    swap    swap    defaults    0    0
```

## Root cause

When `IMAGE_FSTYPES` includes `wic`, the WIC tool updates `/etc/fstab` during image creation based on the `.wks` partition layout. The `luckfox-lyra.wks.in` file defines a swap partition, so WIC appends a generic `/dev/sda5` entry — duplicating the correct `PARTLABEL=SWAP` line already provided by `base-files`.

## Fix

Set `WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"` in the machine configuration so WIC leaves `/etc/fstab` unchanged and uses the rootfs version from `meta-calculinux-distro`.

## Testing

- [ ] Rebuild `calculinux-image` and extract `ROOT_A` from the WIC image
- [ ] Verify `/etc/fstab` contains only `PARTLABEL=SWAP` (no `/dev/sda5` line)
- [ ] Flash and confirm boot no longer shows swap timeout for `/dev/sda5`

Fixes boot delay from spurious swap device wait on devices without `/dev/sda`.

## CI note

Recent workflow runs are failing in the `Determine feed configuration` step with transient `git clone` errors on the self-hosted runner (`GnuTLS recv error` fetching poky/meta-openembedded). This is unrelated to the fstab change. Re-run the workflow when runner networking is healthy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd9809d5-a37b-40ca-8011-90b89c992ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd9809d5-a37b-40ca-8011-90b89c992ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

