### PR TITLE
Raise PicoCalc SPI to 100MHz, plus three build-blocking fetch fixes

### DIFF
--- a/kas-base.yaml
+++ b/kas-base.yaml
@@ -69,6 +69,15 @@ local_conf_header:
     # Skip problematic recipes from meta-retro that use AUTOREV or have missing dependencies
     BBMASK += "meta-retro/recipes-extended/slipr"
     BBMASK += "meta-retro/recipes-graphics/mesa"
+  fetch-user-agent: |
+    # crates.io answers 403 to wget's default User-Agent, so every crate://
+    # fetch falls back to the Yocto source mirror; crates absent from that
+    # mirror fail the build outright. Their crawler policy asks for a
+    # descriptive agent, so send one.
+    # NB: must set the whole value. bb/fetch2/wget.py supplies its default via
+    # `d.getVar("FETCHCMD_wget") or "..."`, so any :append makes the variable
+    # set and silently drops the wget binary from the command.
+    FETCHCMD_wget = "/usr/bin/env wget --tries=2 --timeout=100 --user-agent='calculinux-yocto-build (+https://calculinux.org)'"
   rust-version: |
     # Use meta-lts-mixins' Scarthgap Rust mixin toolchain
     PREFERRED_VERSION_rust = "1.92%"

--- a/meta-calculinux-distro/recipes-bsp/drivers/picocalc-drivers-source.inc
+++ b/meta-calculinux-distro/recipes-bsp/drivers/picocalc-drivers-source.inc
@@ -1,4 +1,4 @@
 PV = "1.0+git${SRCPV}"
-SRC_URI = "git://github.com/Calculinux/picocalc-drivers.git;protocol=https;nobranch=1"
-SRCREV = "6ca8ae70260dd7234c1f64ebf56232038f1f2164"
+SRC_URI = "git://github.com/Pedrocasf/picocalc-drivers.git;protocol=https;nobranch=1"
+SRCREV = "40b939129f7cb2a7f160164264df25b196409f11"
 S = "${WORKDIR}/git"

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/aic8800_1.0.9.bb
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/aic8800_1.0.9.bb
@@ -2,7 +2,7 @@ SUMMARY = "AIC8800 USB Wi-Fi kernel module (DKMS package)"
 DESCRIPTION = "AIC8800 DC/D80/D80X2 USB wireless driver built from official BrosTrend DKMS package. Supports DC WiFi-only variant."
 HOMEPAGE = "https://linux.brostrend.com"
 LICENSE = "GPL-2.0-only"
-PV = "1.0.8"
+PV = "1.0.9"
 
 # License file is extracted from deb package (usr/share/doc/aic8800-dkms/copyright)
 LIC_FILES_CHKSUM = "file://${WORKDIR}/usr/share/doc/aic8800-dkms/copyright;md5=dda5bafa8afaed74f884152b2b3efd00"
@@ -11,11 +11,23 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/usr/share/doc/aic8800-dkms/copyright;md5=d
 # Patches:
 #  0001: Compilation fixes (-Werror, address checking)
 #  0002: Remove FT callback - firmware doesn't implement 802.11r (prevents "Operation not supported")
-SRC_URI = "https://linux.brostrend.com/aic8800-dkms.deb;unpack=0 \
+# Upstream serves every release from one unversioned URL and replaces the file
+# in place (1.0.8 -> 1.0.9 broke the build this way). Two defences:
+#  - downloadfilename pins a versioned name in DL_DIR, so a future in-place
+#    change cannot masquerade as the copy we already fetched.
+#  - CALCULINUX_SOURCE_MIRROR is consulted first, so builds keep working after
+#    upstream rotates the file. Falls back to upstream when the mirror lacks it.
+CALCULINUX_SOURCE_MIRROR ?= "https://opkg.calculinux.org/sources"
+PREMIRRORS:prepend = "https://linux.brostrend.com/.*  ${CALCULINUX_SOURCE_MIRROR}/ \n"
+
+AIC8800_DEB = "aic8800-dkms-${PV}.deb"
+
+SRC_URI = "https://linux.brostrend.com/aic8800-dkms.deb;unpack=0;downloadfilename=${AIC8800_DEB} \
            file://0001-disable-werror-and-fix-address-check.patch \
            file://0002-disable-ft-ies-update.patch \
 "
-SRC_URI[sha256sum] = "952152f3add4ec24fee4af5a677b40135eec7759945268c8539bcc8b8da655eb"
+# sha256 of the 1.0.9 deb (control reports 1.0.9-0b1; source dir is aic8800-1.0.9)
+SRC_URI[sha256sum] = "fd83788d564bb3018e382e236c911a616275e769740e622d42934b5a6f0d714a"
 
 S = "${WORKDIR}/aic8800-${PV}"
 B = "${S}"
@@ -65,13 +77,13 @@ python do_unpack:append() {
     pv = d.getVar('PV')
     
     # With unpack=0, the deb stays in DL_DIR
-    deb_file = os.path.join(dl_dir, 'aic8800-dkms.deb')
+    deb_file = os.path.join(dl_dir, d.getVar('AIC8800_DEB'))
     
     if not os.path.exists(deb_file):
         bb.fatal('DEB file not found in DL_DIR: %s' % deb_file)
     
     # Copy deb to workdir for extraction
-    workdir_deb = os.path.join(workdir, 'aic8800-dkms.deb')
+    workdir_deb = os.path.join(workdir, d.getVar('AIC8800_DEB'))
     shutil.copy(deb_file, workdir_deb)
     
     # Extract deb to workdir

--- a/meta-meshtastic/recipes-connectivity/meshtasticd/meshtasticd_2.6.11.bb
+++ b/meta-meshtastic/recipes-connectivity/meshtasticd/meshtasticd_2.6.11.bb
@@ -10,12 +10,16 @@ LIC_FILES_CHKSUM = " \
 PV = "2.6.11"
 
 SRCREV_FORMAT = "meshtastic_platform"
+# Pinned by SRCREV alone (nobranch=1) rather than tracking `develop`. Upstream
+# rewrites that branch, which orphaned this exact commit and broke do_fetch with
+# "Unable to find revision ... in branch develop". The commit itself is intact
+# and tagged upstream as v2.6.11.60ec05e; only branch ancestry stopped holding.
 SRCREV_meshtastic = "60ec05e53693535aaf616162d4f970cfca6a5d58"
 SRCREV_platform = "622341c6de8a239704318b10c3dbb00c21a3eab3"
 
 SRC_URI = " \
-    git://github.com/meshtastic/firmware.git;branch=develop;protocol=https;submodules=1;name=meshtastic \
-    git://github.com/meshtastic/platform-native.git;branch=develop;protocol=https;destsuffix=platform-native;name=platform \
+    git://github.com/meshtastic/firmware.git;nobranch=1;protocol=https;submodules=1;name=meshtastic \
+    git://github.com/meshtastic/platform-native.git;nobranch=1;protocol=https;destsuffix=platform-native;name=platform \
     file://002-remove-host-include.patch \
     file://003-portduino-buildroot-board.patch \
     file://004-platformio-link-group.patch \

--- a/meta-meshtastic/recipes-connectivity/meshtasticd/meshtasticd_2.6.11.bb
+++ b/meta-meshtastic/recipes-connectivity/meshtasticd/meshtasticd_2.6.11.bb
@@ -10,16 +10,12 @@ LIC_FILES_CHKSUM = " \
 PV = "2.6.11"
 
 SRCREV_FORMAT = "meshtastic_platform"
-# Pinned by SRCREV alone (nobranch=1) rather than tracking `develop`. Upstream
-# rewrites that branch, which orphaned this exact commit and broke do_fetch with
-# "Unable to find revision ... in branch develop". The commit itself is intact
-# and tagged upstream as v2.6.11.60ec05e; only branch ancestry stopped holding.
 SRCREV_meshtastic = "60ec05e53693535aaf616162d4f970cfca6a5d58"
 SRCREV_platform = "622341c6de8a239704318b10c3dbb00c21a3eab3"
 
 SRC_URI = " \
-    git://github.com/meshtastic/firmware.git;nobranch=1;protocol=https;submodules=1;name=meshtastic \
-    git://github.com/meshtastic/platform-native.git;nobranch=1;protocol=https;destsuffix=platform-native;name=platform \
+    git://github.com/meshtastic/firmware.git;branch=develop;protocol=https;submodules=1;name=meshtastic \
+    git://github.com/meshtastic/platform-native.git;branch=develop;protocol=https;destsuffix=platform-native;name=platform \
     file://002-remove-host-include.patch \
     file://003-portduino-buildroot-board.patch \
     file://004-platformio-link-group.patch \

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/0002-spi-rockchip-raise-MAX_SCLK_OUT-to-100MHz.patch
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/0002-spi-rockchip-raise-MAX_SCLK_OUT-to-100MHz.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Calculinux <pedrostarling2000@gmail.com>
+Date: Wed, 19 Aug 2026 16:57:03 +0000
+Subject: [PATCH] spi: rockchip: raise MAX_SCLK_OUT to 100MHz
+
+The driver caps SCLK at 50MHz for every SoC it supports, from rk3036
+through rk3506, with a single constant and no per-SoC differentiation.
+Nothing in the hardware requires that value: BAUDR is a 16-bit even
+divider with a minimum of 2, programmed as
+
+	2 * DIV_ROUND_UP(freq, 2 * speed)
+
+so any rate up to spiclk/2 is representable. The cap is the only thing
+between a board and the top of its clock tree, and it applies silently:
+rk3399-khadas-edge asks for 104MHz on spi1 and is clamped without a
+word in the log.
+
+On the PicoCalc the SPI panel is the bandwidth bottleneck. A 320x320
+RGB565 frame is 200KiB, which is ~33ms of bus time at 50MHz and ~16ms
+at 100MHz, so the cap costs roughly half the achievable frame rate.
+
+Raise it to 100MHz, which is what spi0 reaches on rk3506 with its
+functional clock pinned at 200MHz. This changes no board on its own;
+spi-max-frequency and the clock tree still decide the rate, and boards
+that ask for less are unaffected.
+
+Not upstream material as-is: the right fix is a per-SoC limit driven by
+each TRM rather than one number for the whole family. Carried here so
+the PicoCalc display can use the bandwidth its panel bus has.
+
+Signed-off-by: Calculinux <pedrostarling2000@gmail.com>
+---
+ drivers/spi/spi-rockchip.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/spi/spi-rockchip.c b/drivers/spi/spi-rockchip.c
+index 725edce99..cc9351533 100644
+--- a/drivers/spi/spi-rockchip.c
++++ b/drivers/spi/spi-rockchip.c
+@@ -155,8 +155,13 @@
+ #define RXDMA					(1 << 0)
+ #define TXDMA					(1 << 1)
+ 
+-/* sclk_out: spi master internal logic in rk3x can support 50Mhz */
+-#define MAX_SCLK_OUT				50000000U
++/*
++ * sclk_out: this driver has always capped every rk3x SoC at 50MHz. The BAUDR
++ * divider is 16-bit, even, minimum 2, so the hardware can be programmed all
++ * the way up to spiclk/2 and the cap is the only thing in the way. Raise it
++ * and let spi-max-frequency and the board's clock tree pick the real rate.
++ */
++#define MAX_SCLK_OUT				100000000U
+ /* max sclk of driver strength 4mA */
+ #define IO_DRIVER_4MA_MAX_SCLK_OUT	24000000U
+ 

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -20,6 +20,7 @@ SRC_URI = " \
     file://usb-gadget.cfg \
     file://mmc-spi-fix-nullpointer-on-shutdown.patch \
     file://0001-of-configfs-overlay-interface.patch \
+    file://0002-spi-rockchip-raise-MAX_SCLK_OUT-to-100MHz.patch \
 "
 
 KERNEL_CONFIG_FRAGMENTS += " \


### PR DESCRIPTION
## What this does

Raises the PicoCalc display SPI clock from an effective 50MHz to 100MHz, and fixes three unrelated failures that block a from-scratch build today.

### SPI 100MHz (`d80ec1f`, `695dded`)

The rockchip SPI driver caps SCLK at 50MHz for every SoC with a single constant. Nothing in the hardware requires it: BAUDR is a 16-bit even divider with a minimum of 2, so any rate up to `spiclk/2` is representable.

A 320x320 RGB565 frame is 200KiB — ~33ms of bus time at 50MHz, ~16ms at 100MHz — so the cap costs roughly half the achievable frame rate.

Two halves, neither of which does anything alone:
- kernel patch raising `MAX_SCLK_OUT` to 100MHz
- `picocalc-drivers` bumped to a revision setting `spi-max-frequency = <100000000>` (was 80000000, silently clamped to 50MHz)

### Build fixes

**`aic8800` (`344047a`)** — BrosTrend serves every release from one unversioned URL and replaced the file in place, so the pinned sha256 stopped matching and `do_fetch` failed. Bumped to 1.0.9 (`PV` must change: the deb extracts to `aic8800-1.0.9`). Verified `LIC_FILES_CHKSUM` is unchanged and both local patches still apply. Added `downloadfilename` to pin a versioned name in `DL_DIR` and a source-mirror premirror so the next in-place rotation can't break the build the same way.

**`crates.io` 403s (`4931794`)** — crates.io rejects wget's default User-Agent. Every `crate://` fetch was falling back to the Yocto source mirror, producing ~640 warnings per build and hard-failing for crates absent from that mirror (`better-panic`, `bumpalo`). Now sends a descriptive agent, as their crawler policy asks.

Note the whole `FETCHCMD_wget` value must be assigned, not appended: bitbake supplies its default via `d.getVar("FETCHCMD_wget") or "..."`, so any `:append` makes the variable set, defeats the fallback, and silently drops the `wget` binary from the command (exit 127).

## Reviewer notes

**`695dded` points `picocalc-drivers` at a personal fork** (`Pedrocasf/picocalc-drivers`) rather than `Calculinux/`. That is deliberate for the SPI work but likely wants redirecting to a `Calculinux/` revision before merge. Verified the fork satisfies the layout the recipes require: all five device tree files at repo root and all ten `obj-m` modules.

**`5edc9e5` and `b7fe46e` cancel out** — a fix and its revert, kept as a pair rather than squashed because the revert message records a genuinely useful diagnosis. `meshtasticd do_fetch` was failing with `Unable to find revision ... in branch develop`, which looked like upstream orphaning the commit. It was not: the commit is an ancestor of `develop`, and the real fault was a corrupt bare mirror in `DL_DIR/git2` left by a killed build — its HEAD was dangling, so `git branch --contains` aborted and bitbake read the empty output as a missing revision. Three other mirrors were corrupt identically (`vim`, `mame2003-plus-libretro`, `ZeroTierOne`). Worth knowing for CI, where killed builds are routine: check `git --git-dir=<mirror> rev-parse HEAD` before believing a revision is gone. Squash both out if you prefer a clean history.

## Testing

Built with `kas` for `luckfox-lyra`. Each change verified individually:
- SPI patch applies — confirmed as `#define MAX_SCLK_OUT 100000000U` in the kernel source tree, not just a green `do_patch`
- `aic8800` 1.0.9 — `do_fetch`, `do_unpack`, `do_patch` all succeed
- crates.io — 0 errors and 0 mirror fallbacks, down from 640 warnings
- `picocalc-drivers` fork — fetched, `spi-max-frequency = <100000000>` confirmed at the pinned revision

A full image build was still in progress at the time of opening; the runtime effect of the 100MHz clock on real hardware has **not** been measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)