### PR TITLE
Add uwific TUI WiFi manager to the image

### DIFF
--- a/meta-calculinux-apps/recipes-apps/uwific/uwific_git.bb
+++ b/meta-calculinux-apps/recipes-apps/uwific/uwific_git.bb
@@ -1,0 +1,35 @@
+SUMMARY = "TUI WiFi manager for iwd"
+DESCRIPTION = "A small-screen TUI WiFi client that talks to iwd over D-Bus. \
+Scans, connects, disconnects, and forgets networks using ncurses. Designed \
+for Calculinux on PicoCalc-class devices."
+HOMEPAGE = "https://github.com/RealBusinessAccount/uwific"
+SECTION = "console/network"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=574efe748ed4af8e3c587194e64d9ea8"
+
+SRC_URI = "git://github.com/RealBusinessAccount/uwific.git;protocol=https;branch=main"
+SRCREV = "961bc1dd0358f61aadd7ca6a0a5f76b9856ce80d"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig
+
+DEPENDS = "systemd ncurses"
+
+EXTRA_OEMAKE = "\
+    CC='${CC}' \
+    CFLAGS='${CFLAGS} `pkg-config --cflags libsystemd ncurses`' \
+    LIBS='${LDFLAGS} `pkg-config --libs libsystemd ncurses`' \
+    PREFIX=${prefix} \
+"
+
+do_compile() {
+    oe_runmake
+}
+
+do_install() {
+    oe_runmake install DESTDIR=${D} PREFIX=${prefix}
+}
+
+RDEPENDS:${PN} = "iwd"

--- a/meta-calculinux-apps/recipes-apps/uwific/uwific_git.bb
+++ b/meta-calculinux-apps/recipes-apps/uwific/uwific_git.bb
@@ -11,6 +11,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=574efe748ed4af8e3c587194e64d9ea8"
 SRC_URI = "git://github.com/RealBusinessAccount/uwific.git;protocol=https;branch=main"
 SRCREV = "961bc1dd0358f61aadd7ca6a0a5f76b9856ce80d"
 
+PV = "1.0+git${SRCPV}"
+
 S = "${WORKDIR}/git"
 
 inherit pkgconfig

--- a/meta-calculinux-apps/recipes-core/packagegroups/packagegroup-meta-calculinux-apps.bb
+++ b/meta-calculinux-apps/recipes-core/packagegroups/packagegroup-meta-calculinux-apps.bb
@@ -119,6 +119,7 @@ RDEPENDS:${PN} = " \
     tic-80 \
     tmux \
     tree \
+    uwific \
     valgrind \
     vice-libretro \
     vim \

--- a/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
+++ b/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
@@ -90,6 +90,7 @@ IMAGE_INSTALL += " \
     unzip \
     usb-gadget-network \
     usbutils \
+    uwific \
     util-linux \
     wget \
     which \


### PR DESCRIPTION
## Summary
- Add a recipe for [uwific](https://github.com/RealBusinessAccount/uwific), a small-screen TUI that talks to iwd over D-Bus
- Include it in `packagegroup-meta-calculinux-apps` so the IPK is in the feed
- Preinstall it on `calculinux-image` next to `iwd`

## Test plan
- [x] `bitbake uwific` fetches, compiles, and writes the IPK
- [ ] Flash or update an image and confirm `/usr/bin/uwific` is present
- [ ] On device: `sudo uwific` lists networks and can connect via iwd


Made with [Cursor](https://cursor.com)