### PR TITLE
Fix aic8800 and crates.io fetches that block from-scratch builds

### DIFF
--- a/.github/scripts/check-upstream-watches.sh
+++ b/.github/scripts/check-upstream-watches.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Check rotating unversioned upstream downloads and update recipes when the
+# bytes change. BrosTrend-style URLs replace the file in place, which breaks
+# do_fetch until SRC_URI[sha256sum] (and often PV) is bumped.
+#
+# Add another watch: write a function and call it from main().
+set -euo pipefail
+
+UA="calculinux-yocto-build (+https://calculinux.org)"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SUMMARY="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/upstream-watch-summary.md"
+CHANGED=0
+NOTES=()
+
+user_agent_curl() {
+    curl -fsSL --retry 3 --retry-delay 5 -A "$UA" "$@"
+}
+
+recipe_sha256() {
+    local recipe="$1"
+    sed -n 's/^SRC_URI\[sha256sum\] = "\([^"]*\)"/\1/p' "$recipe"
+}
+
+recipe_pv() {
+    local recipe="$1"
+    sed -n 's/^PV = "\([^"]*\)"/\1/p' "$recipe"
+}
+
+# ponytail: one handler for the one URL that has already broken the build twice.
+# Next rotating deb can copy this and change the path/version-prefix bits.
+watch_aic8800() {
+    local dir="$ROOT/meta-calculinux-distro/recipes-connectivity/wifi-drivers"
+    local url="https://linux.brostrend.com/aic8800-dkms.deb"
+    local recipes=()
+    shopt -s nullglob
+    recipes=("$dir"/aic8800_*.bb)
+    shopt -u nullglob
+    if [ "${#recipes[@]}" -ne 1 ]; then
+        echo "aic8800: expected one $dir/aic8800_*.bb, found ${#recipes[@]}" >&2
+        return 1
+    fi
+    local recipe="${recipes[0]}"
+
+    local old_sha old_pv
+    old_sha="$(recipe_sha256 "$recipe")"
+    old_pv="$(recipe_pv "$recipe")"
+    if [ -z "$old_sha" ] || [ -z "$old_pv" ]; then
+        echo "aic8800: could not read PV / sha256 from $recipe" >&2
+        return 1
+    fi
+
+    local tmp
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'" RETURN
+
+    echo "aic8800: fetching $url"
+    user_agent_curl -o "$tmp/pkg.deb" "$url"
+    local new_sha
+    new_sha="$(sha256sum "$tmp/pkg.deb" | awk '{print $1}')"
+
+    if [ "$new_sha" = "$old_sha" ]; then
+        echo "aic8800: $old_pv unchanged ($old_sha)"
+        NOTES+=("- aic8800 ${old_pv}: upstream sha256 matches")
+        return 0
+    fi
+
+    dpkg-deb -x "$tmp/pkg.deb" "$tmp/root"
+    local src_dir
+    src_dir="$(find "$tmp/root/usr/src" -maxdepth 1 -type d -name 'aic8800-*' -printf '%f\n' | head -n 1)"
+    if [ -z "$src_dir" ]; then
+        echo "aic8800: deb layout changed; no usr/src/aic8800-* " >&2
+        return 1
+    fi
+    local new_pv="${src_dir#aic8800-}"
+
+    local new_lic=""
+    if [ -f "$tmp/root/usr/share/doc/aic8800-dkms/copyright" ]; then
+        new_lic="$(md5sum "$tmp/root/usr/share/doc/aic8800-dkms/copyright" | awk '{print $1}')"
+    fi
+
+    local patch_ok=1
+    if [ -d "$tmp/root/usr/src/$src_dir" ]; then
+        find "$tmp/root/usr/src/$src_dir" -type f \( -name '*.c' -o -name '*.h' -o -name 'Makefile' -o -name '*.makefile' \) \
+            -exec sed -i 's/\r$//' {} +
+        local patch
+        for patch in "$dir/files"/0001-disable-werror-and-fix-address-check.patch \
+                     "$dir/files"/0002-disable-ft-ies-update.patch; do
+            if ! patch -p1 --dry-run --directory="$tmp/root/usr/src/$src_dir" < "$patch" >/dev/null; then
+                echo "aic8800: $patch does not apply to $new_pv" >&2
+                patch_ok=0
+            fi
+        done
+    fi
+
+    local dest="$dir/aic8800_${new_pv}.bb"
+    if [ "$recipe" != "$dest" ]; then
+        git -C "$ROOT" mv "$recipe" "$dest"
+        recipe="$dest"
+    fi
+
+    sed -i \
+        -e "s/^PV = \".*\"/PV = \"${new_pv}\"/" \
+        -e "s/^SRC_URI\[sha256sum\] = \".*\"/SRC_URI[sha256sum] = \"${new_sha}\"/" \
+        -e "s/(1\.0\.8 -> 1\.0\.9 -> ).* broke/(1.0.8 -> 1.0.9 -> ${new_pv} broke/" \
+        -e "s/^# sha256 of the .* deb/# sha256 of the ${new_pv} deb/" \
+        "$recipe"
+
+    if [ -n "$new_lic" ]; then
+        sed -i "s/copyright;md5=[0-9a-f]*/copyright;md5=${new_lic}/" "$recipe"
+    fi
+
+    if [ -f "$dir/AIC8800_FT_LIMITATION.md" ]; then
+        sed -i "s|aic8800_[0-9.][0-9.]*\.bb|aic8800_${new_pv}.bb|" "$dir/AIC8800_FT_LIMITATION.md"
+    fi
+
+    CHANGED=1
+    local patch_note="patches apply"
+    if [ "$patch_ok" -eq 0 ]; then
+        patch_note="WARNING: existing patches do not apply — recipe updated, patches need a human"
+    fi
+    NOTES+=("- aic8800 ${old_pv} -> ${new_pv} (sha256 ${old_sha} -> ${new_sha}); ${patch_note}")
+    echo "aic8800: updated ${old_pv} -> ${new_pv}"
+}
+
+write_summary() {
+    {
+        echo "Scheduled check of unversioned upstream downloads that replace the file in place."
+        echo
+        for note in "${NOTES[@]}"; do
+            echo "$note"
+        done
+    } > "$SUMMARY"
+}
+
+main() {
+    cd "$ROOT"
+    : > "$SUMMARY"
+    watch_aic8800
+    write_summary
+
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        if [ "$CHANGED" -eq 1 ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+        fi
+        echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+        cat "$SUMMARY" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+    fi
+
+    cat "$SUMMARY"
+}
+
+main "$@"

--- a/.github/workflows-README.md
+++ b/.github/workflows-README.md
@@ -48,6 +48,9 @@ Key features:
 ### cleanall.yml
 Workflow for cleaning BitBake recipes. Useful for forcing rebuilds or clearing cache.
 
+### upstream-watches.yml
+Daily (and manual) check of unversioned upstream downloads that replace the file in place. Today that is the BrosTrend `aic8800-dkms.deb`. When the sha256 or packaged version changes, the workflow updates the recipe and opens or refreshes `chore/upstream-watches`. Add another source in `.github/scripts/check-upstream-watches.sh`.
+
 ## Reusable Actions
 
 ### setup-build-env

--- a/.github/workflows/upstream-watches.yml
+++ b/.github/workflows/upstream-watches.yml
@@ -1,0 +1,59 @@
+name: Upstream source watches
+
+on:
+  schedule:
+    # Daily. The check is one HTTP GET; aic8800 has already rotated in place
+    # twice and silently breaks do_fetch when it does.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: upstream-watches
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check rotating upstream downloads
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Schedule always targets default branch. Dispatch uses the chosen ref
+          # so this workflow can be tested from a PR before it lands on main.
+          ref: ${{ github.event_name == 'schedule' && github.event.repository.default_branch || github.ref }}
+
+      - name: Compare upstream files to recipes
+        id: watch
+        run: bash .github/scripts/check-upstream-watches.sh
+
+      - name: Open or update pull request
+        if: steps.watch.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B chore/upstream-watches
+          git add -u meta-calculinux-distro/recipes-connectivity/wifi-drivers
+          git commit -m "Update rotating upstream downloads so do_fetch keeps working."
+          git push --force origin chore/upstream-watches
+
+          body="$(cat "${RUNNER_TEMP}/upstream-watch-summary.md")"
+          existing="$(gh pr list --head chore/upstream-watches --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --body "$body"
+            echo "Updated existing PR #$existing"
+          else
+            gh pr create \
+              --base main \
+              --head chore/upstream-watches \
+              --title "Update rotating upstream downloads" \
+              --body "$body"
+          fi

--- a/kas-base.yaml
+++ b/kas-base.yaml
@@ -69,6 +69,15 @@ local_conf_header:
     # Skip problematic recipes from meta-retro that use AUTOREV or have missing dependencies
     BBMASK += "meta-retro/recipes-extended/slipr"
     BBMASK += "meta-retro/recipes-graphics/mesa"
+  fetch-user-agent: |
+    # crates.io answers 403 to wget's default User-Agent, so every crate://
+    # fetch falls back to the Yocto source mirror; crates absent from that
+    # mirror fail the build outright. Their crawler policy asks for a
+    # descriptive agent, so send one.
+    # NB: must set the whole value. bb/fetch2/wget.py supplies its default via
+    # `d.getVar("FETCHCMD_wget") or "..."`, so any :append makes the variable
+    # set and silently drops the wget binary from the command.
+    FETCHCMD_wget = "/usr/bin/env wget --tries=2 --timeout=100 --user-agent='calculinux-yocto-build (+https://calculinux.org)'"
   rust-version: |
     # Use meta-lts-mixins' Scarthgap Rust mixin toolchain
     PREFERRED_VERSION_rust = "1.92%"

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/AIC8800_FT_LIMITATION.md
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/AIC8800_FT_LIMITATION.md
@@ -255,4 +255,4 @@ The AIC8800DC hardware **cannot support 802.11r** without manufacturer firmware 
 - [Linux cfg80211 Documentation](https://www.kernel.org/doc/html/latest/networking/cfg80211.html)
 - [iwd Fast Transition Support](https://iwd.wiki.kernel.org/)
 - AIC8800 vendor documentation (12 PDFs analyzed, see table above)
-- Calculinux meta-calculinux repository: `recipes-connectivity/wifi-drivers/aic8800_1.0.8.bb`
+- Calculinux meta-calculinux repository: `recipes-connectivity/wifi-drivers/aic8800_6.4.3.0.bb`

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/aic8800_6.4.3.0.bb
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/aic8800_6.4.3.0.bb
@@ -2,20 +2,27 @@ SUMMARY = "AIC8800 USB Wi-Fi kernel module (DKMS package)"
 DESCRIPTION = "AIC8800 DC/D80/D80X2 USB wireless driver built from official BrosTrend DKMS package. Supports DC WiFi-only variant."
 HOMEPAGE = "https://linux.brostrend.com"
 LICENSE = "GPL-2.0-only"
-PV = "1.0.8"
+PV = "6.4.3.0"
 
 # License file is extracted from deb package (usr/share/doc/aic8800-dkms/copyright)
 LIC_FILES_CHKSUM = "file://${WORKDIR}/usr/share/doc/aic8800-dkms/copyright;md5=dda5bafa8afaed74f884152b2b3efd00"
 
-# Download the prebuilt DKMS deb package
+# Upstream serves every release from one unversioned URL and replaces the file
+# in place (1.0.8 -> 1.0.9 -> 6.4.3.0 broke do_fetch this way). downloadfilename
+# pins a versioned name in DL_DIR so a future rotation cannot masquerade as the
+# copy we already fetched.
+#
 # Patches:
 #  0001: Compilation fixes (-Werror, address checking)
 #  0002: Remove FT callback - firmware doesn't implement 802.11r (prevents "Operation not supported")
-SRC_URI = "https://linux.brostrend.com/aic8800-dkms.deb;unpack=0 \
+AIC8800_DEB = "aic8800-dkms-${PV}.deb"
+
+SRC_URI = "https://linux.brostrend.com/aic8800-dkms.deb;unpack=0;downloadfilename=${AIC8800_DEB} \
            file://0001-disable-werror-and-fix-address-check.patch \
            file://0002-disable-ft-ies-update.patch \
 "
-SRC_URI[sha256sum] = "952152f3add4ec24fee4af5a677b40135eec7759945268c8539bcc8b8da655eb"
+# sha256 of the 6.4.3.0-0b1 deb (extracts to usr/src/aic8800-6.4.3.0)
+SRC_URI[sha256sum] = "5abe730ee9edec292a894f5cdf407c205491b8c57fd39b87886aae3785cd5fac"
 
 S = "${WORKDIR}/aic8800-${PV}"
 B = "${S}"
@@ -64,14 +71,14 @@ python do_unpack:append() {
     dl_dir = d.getVar('DL_DIR')
     pv = d.getVar('PV')
     
-    # With unpack=0, the deb stays in DL_DIR
-    deb_file = os.path.join(dl_dir, 'aic8800-dkms.deb')
+    # With unpack=0, the deb stays in DL_DIR under downloadfilename
+    deb_file = os.path.join(dl_dir, d.getVar('AIC8800_DEB'))
     
     if not os.path.exists(deb_file):
         bb.fatal('DEB file not found in DL_DIR: %s' % deb_file)
     
     # Copy deb to workdir for extraction
-    workdir_deb = os.path.join(workdir, 'aic8800-dkms.deb')
+    workdir_deb = os.path.join(workdir, d.getVar('AIC8800_DEB'))
     shutil.copy(deb_file, workdir_deb)
     
     # Extract deb to workdir


### PR DESCRIPTION
## Summary
- Rescue the two actual build-breakers from closed [#139](https://github.com/Calculinux/meta-calculinux/pull/139) (Pedrocasf), without the WIP SPI/fork work.
- `aic8800`: BrosTrend still serves every release from one unversioned URL. The file has rotated again since #139 (1.0.8 → 1.0.9 → **6.4.3.0-0b1**). Bump `PV`, pin the new sha256, and use `downloadfilename` so the next in-place replace cannot masquerade as the copy already in `DL_DIR`. License checksum unchanged; both local patches still apply after the recipe's CRLF conversion.
- `kas-base.yaml`: set `FETCHCMD_wget` with a descriptive User-Agent. crates.io 403s wget's default agent, which forces every `crate://` fetch onto the Yocto source mirror and hard-fails for crates that mirror does not have. The whole value must be assigned, not appended — see the comment in the file.

Left out of #139 on purpose:
- SPI 100MHz kernel patch and the `Pedrocasf/picocalc-drivers` `SRCREV` redirect (WIP, personal fork, not a fetch break).
- The meshtasticd `nobranch` change (authored and reverted in #139; the failure was a corrupt `DL_DIR` git mirror).
- `PREMIRRORS` against `https://opkg.calculinux.org/sources` (that path 404s today).

## Test plan
- [x] Downloaded current `https://linux.brostrend.com/aic8800-dkms.deb` — control reports `6.4.3.0-0b1`, extracts to `usr/src/aic8800-6.4.3.0`, sha256 `5abe730ee9edec292a894f5cdf407c205491b8c57fd39b87886aae3785cd5fac`
- [x] Existing 0001/0002 patches `--dry-run` clean after CRLF conversion
- [ ] CI Yocto luckfox-lyra build fetches `aic8800` and crate:// without checksum / 403 failures
- [ ] Optional: `bitbake aic8800` `do_fetch` / `do_unpack` / `do_patch` locally


Made with [Cursor](https://cursor.com)