### PR TITLE
Hardware overlay docs for FIT merge-at-boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ managed directly through ConfigFS at runtime without building an external module
 4. Echo `1` into the matching `status` attribute to apply the overlay, or `0` to remove it again.
 
 This matches the workflow documented upstream in the `dtbocfg`/OpenWrt examples while keeping the code in-tree.
-Place reusable overlays in `/lib/firmware/overlays` (or another directory of your choosing) so
+Place reusable overlays in `/boot/devicetree` (or `/etc/devicetree` for overrides) so
 they can be easily copied into ConfigFS when needed.
 
 ---

--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ managed directly through ConfigFS at runtime without building an external module
 2. Create a directory under `/sys/kernel/config/device-tree/overlays/<name>` for each overlay you want to
    stage.
 3. Copy the compiled overlay blob (`*.dtbo`) into the `dtbo` attribute inside that directory.
-4. Echo `1` into the matching `status` attribute to apply the overlay, or `0` to remove it again.
+   The kernel applies the overlay on that write; `status` is read-only.
+4. Confirm it applied (`cat .../status` should print `applied`). To unload, `rmdir` the overlay directory.
 
-This matches the workflow documented upstream in the `dtbocfg`/OpenWrt examples while keeping the code in-tree.
+This matches `load-dt-overlays.sh` (write `dtbo`, then check `status` for `applied`).
 Place reusable overlays in `/boot/devicetree` (or `/etc/devicetree` for overrides) so
 they can be easily copied into ConfigFS when needed.
 

--- a/docs/DEVICE-TREE-OVERLAYS.md
+++ b/docs/DEVICE-TREE-OVERLAYS.md
@@ -1,12 +1,15 @@
 # Device Tree Overlays for Calculinux
 
-Calculinux supports runtime device tree overlays using the kernel's ConfigFS interface, allowing you to enable hardware modules without rebuilding the entire image.
+Calculinux supports device tree overlays in two ways:
+
+- **Default (persistent)**: merge overlays into the boot DTB/FIT for the **next boot**
+- **Developer option (non-persistent)**: apply overlays at runtime via ConfigFS
 
 ## Available Overlays
 
 ### DS3231 I2C RTC Module
 
-**File**: `/lib/firmware/overlays/ds3231-rtc.dtbo`  
+**File**: `/boot/devicetree/ds3231-rtc.dtbo`  
 **Recipe**: `picocalc-dt-overlays`  
 **Documentation**: [DS3231-RTC.md](DS3231-RTC.md)
 
@@ -14,23 +17,68 @@ Enables the Maxim DS3231 Real-Time Clock module on I2C bus 2.
 
 ### I2C Bus 2 @ 100 kHz
 
-**File**: `/lib/firmware/overlays/100khz-i2c.dtbo`  
+**File**: `/boot/devicetree/100khz-i2c.dtbo`  
 **Recipe**: `picocalc-dt-overlays`
 
 Reduces the I2C2 bus clock from 400 kHz to 100 kHz.
 
-## How Overlays Work
+### PCM5102A I2S DAC Module
 
-Device tree overlays in Calculinux use the upstream kernel ConfigFS interface (`drivers/of/configfs`), providing a standardized way to load and unload device tree fragments at runtime without requiring external modules.
+**File**: `/boot/devicetree/pcm5102a-i2s.dtbo`  
+**Recipe**: `picocalc-dt-overlays`  
+**Documentation**: [PCM5102A-I2S-DAC.md](PCM5102A-I2S-DAC.md)
 
-### Loading an Overlay
+Enables I2S audio output via the PCM5102A DAC module on RMII1 test pads. Provides high-quality audio output for the PicoCalc.
+
+### SX1262 LoRA Module (Meshtastic)
+
+**File**: `/boot/devicetree/sx1262-lora.dtbo`  
+**Recipe**: `picocalc-dt-overlays`  
+**Documentation**: [SX1262-LORA-MESHTASTIC.md](SX1262-LORA-MESHTASTIC.md)
+
+Configures GPIO pins for software SPI communication with the Waveshare SX1262 LoRA transceiver on RMII1 test pads. Enables Meshtastic mesh networking capabilities.
+
+### u-blox NEO-M8N GPS Module
+
+**File**: `/boot/devicetree/neo-m8n-gps.dtbo`  
+**Recipe**: `picocalc-dt-overlays`  
+**Documentation**: [NEO-M8N-GPS.md](NEO-M8N-GPS.md)
+
+Enables UART5 for communication with the u-blox NEO-M8N GPS module on RMII1 test pads. Compatible with gpsd and standard NMEA applications. Can be used alongside the SX1262 LoRA module for GPS-equipped Meshtastic nodes.
+
+## Default (Persistent) Behavior: Merge for Next Boot
+
+List overlays in `/etc/device-tree-overlays.conf`. `merge-dt-overlays-boot` runs at boot and
+when that config (or `/etc/devicetree/`) changes, and writes
+`/data/fit/zboot_merged_<rauc-slot>.img` for the **current** RAUC slot only.
+
+U-Boot loads that slot's FIT, then `/boot/zboot_merged.img` on the same root, then
+unmerged `zboot.img`. It never boots the other slot's FIT (that FIT has the other
+slot's kernel). A RAUC install deletes the target slot's merged FIT so the first
+boot after update uses `/boot/zboot_merged.img`.
+
+Notes:
+
+- **Changes require a reboot** to take effect.
+- The image does not enable hardware overlays by default; add names such as `sx1262-lora` to the config.
+- Overlays are resolved from `/etc/devicetree/` first (user overrides), then `/boot/devicetree/` (image-provided).
+
+## Runtime Overlay Loading (ConfigFS) (Developer Option)
+
+Device tree overlays can also be loaded after boot using the kernel's ConfigFS interface, providing flexibility for development and testing.
+
+### How Overlays Work
+
+Device tree overlays use the upstream kernel ConfigFS interface (`drivers/of/configfs`), providing a standardized way to load and unload device tree fragments at runtime without requiring external modules.
+
+### Loading an Overlay at Runtime
 
 ```bash
 # 1. Create overlay directory
 mkdir -p /sys/kernel/config/device-tree/overlays/<overlay-name>
 
 # 2. Load the compiled overlay
-cat /lib/firmware/overlays/<overlay-name>.dtbo > /sys/kernel/config/device-tree/overlays/<overlay-name>/dtbo
+cat /boot/devicetree/<overlay-name>.dtbo > /sys/kernel/config/device-tree/overlays/<overlay-name>/dtbo
 
 # 3. Activate the overlay
 echo 1 > /sys/kernel/config/device-tree/overlays/<overlay-name>/status
@@ -48,13 +96,14 @@ rmdir /sys/kernel/config/device-tree/overlays/<overlay-name>
 
 ### Making Overlays Persistent
 
-Overlays loaded via ConfigFS don't persist across reboots. To load them automatically, create a systemd service (see [DS3231-RTC.md](DS3231-RTC.md) for an example).
+Overlays loaded via ConfigFS don't persist across reboots. For persistent behavior, use `/etc/device-tree-overlays.conf`
+and reboot (merged-boot behavior).
 
 ## Creating New Overlays
 
 ### 1. Add Overlay Source to picocalc-drivers Repository
 
-Create a `.dts` file in the [picocalc-drivers](https://github.com/Calculinux/picocalc-drivers) repository:
+Create a `.dts` file in the [picocalc-drivers](https://github.com/Calculinux/picocalc-drivers) repository under `overlays/` (generic) or `luckfox-lyra/overlays/` (Lyra-specific):
 
 ```dts
 /dts-v1/;
@@ -72,55 +121,51 @@ Create a `.dts` file in the [picocalc-drivers](https://github.com/Calculinux/pic
 };
 ```
 
-### 2. Create a Yocto Recipe
+**Naming Convention**: `<purpose>-overlay.dts` (e.g., `custom-device-overlay.dts`)
 
-Create a recipe in `meta-calculinux-distro/recipes-bsp/drivers/` like `picocalc-<device>-overlay_1.0.bb`:
+The compiled output will be `<purpose>.dtbo` (e.g., `custom-device.dtbo`)
 
-```bitbake
-SUMMARY = "Device tree overlay for <device>"
-LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+### 2. Update picocalc-dt-overlays Recipe (Optional)
 
-PR = "r0"
-
-require picocalc-drivers-source.inc
-
-COMPATIBLE_MACHINE = "luckfox-lyra"
-DEPENDS = "dtc-native"
-
-do_compile() {
-    dtc -@ -I dts -O dtb -o ${B}/<overlay-name>.dtbo ${S}/<overlay-source>.dts
-}
-
-do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/overlays
-    install -m 0644 ${B}/<overlay-name>.dtbo ${D}${nonarch_base_libdir}/firmware/overlays/
-}
-
-FILES:${PN} = "${nonarch_base_libdir}/firmware/overlays/<overlay-name>.dtbo"
-PACKAGES = "${PN}"
-```
-
-### 3. Add to Image
-
-Update `kas-luckfox-lyra-bundle.yaml` to include the overlay in `PICOCALC_DRIVERS`:
-
-```yaml
-PICOCALC_DRIVERS = "\
-  picocalc-drivers-lcd-drm \
-  picocalc-drivers-snd-pwm \
-  picocalc-drivers-snd-softpwm \
-  picocalc-drivers-mfd \
-  picocalc-<device>-overlay \
-"
-```
-
-### 4. Update picocalc-drivers SRCREV
-
-After committing to picocalc-drivers, update the commit hash in `picocalc-drivers-source.inc`:
+If adding to the official distribution, the consolidated `picocalc-dt-overlays` recipe will automatically compile and install your `.dts` file. Just update `picocalc-drivers-source.inc` with the new commit hash:
 
 ```bitbake
 SRCREV = "<new-commit-hash>"
+```
+
+For one-off overlays not in the main build, you can manually compile:
+
+```bash
+# On device or build host with dtc installed
+dtc -@ -I dts -O dtb -o my-overlay.dtbo my-overlay-overlay.dts
+cp my-overlay.dtbo /etc/devicetree/
+```
+
+### 3. Testing Your Overlay
+
+**Option A: Boot-Time Loading (Easier)**
+
+Add the overlay name (or absolute path) to `/etc/device-tree-overlays.conf`,
+copy the `.dtbo` to `/etc/devicetree/` (or `/boot/devicetree/`), reboot, and check boot logs:
+
+```bash
+ssh pico@192.168.7.2 dmesg | grep -i overlay
+```
+
+**Option B: Runtime Loading (Quick Iteration)**
+
+Test with ConfigFS before committing to the image:
+
+```bash
+mkdir -p /sys/kernel/config/device-tree/overlays/my-overlay
+cat /etc/devicetree/my-overlay.dtbo > /sys/kernel/config/device-tree/overlays/my-overlay/dtbo
+echo 1 > /sys/kernel/config/device-tree/overlays/my-overlay/status
+```
+
+Check dmesg for any errors:
+
+```bash
+dmesg | tail -20
 ```
 
 ## Common I2C Buses

--- a/docs/DEVICE-TREE-OVERLAYS.md
+++ b/docs/DEVICE-TREE-OVERLAYS.md
@@ -77,20 +77,16 @@ Device tree overlays use the upstream kernel ConfigFS interface (`drivers/of/con
 # 1. Create overlay directory
 mkdir -p /sys/kernel/config/device-tree/overlays/<overlay-name>
 
-# 2. Load the compiled overlay
+# 2. Write the compiled overlay (kernel applies on this write; status is read-only)
 cat /boot/devicetree/<overlay-name>.dtbo > /sys/kernel/config/device-tree/overlays/<overlay-name>/dtbo
 
-# 3. Activate the overlay
-echo 1 > /sys/kernel/config/device-tree/overlays/<overlay-name>/status
+# 3. Confirm it applied
+cat /sys/kernel/config/device-tree/overlays/<overlay-name>/status   # expect: applied
 ```
 
 ### Unloading an Overlay
 
 ```bash
-# 1. Deactivate
-echo 0 > /sys/kernel/config/device-tree/overlays/<overlay-name>/status
-
-# 2. Remove directory
 rmdir /sys/kernel/config/device-tree/overlays/<overlay-name>
 ```
 
@@ -137,8 +133,8 @@ For one-off overlays not in the main build, you can manually compile:
 
 ```bash
 # On device or build host with dtc installed
-dtc -@ -I dts -O dtb -o my-overlay.dtbo my-overlay-overlay.dts
-cp my-overlay.dtbo /etc/devicetree/
+dtc -@ -I dts -O dtb -o custom-device.dtbo custom-device-overlay.dts
+cp custom-device.dtbo /etc/devicetree/
 ```
 
 ### 3. Testing Your Overlay
@@ -157,9 +153,9 @@ ssh pico@192.168.7.2 dmesg | grep -i overlay
 Test with ConfigFS before committing to the image:
 
 ```bash
-mkdir -p /sys/kernel/config/device-tree/overlays/my-overlay
-cat /etc/devicetree/my-overlay.dtbo > /sys/kernel/config/device-tree/overlays/my-overlay/dtbo
-echo 1 > /sys/kernel/config/device-tree/overlays/my-overlay/status
+mkdir -p /sys/kernel/config/device-tree/overlays/custom-device
+cat /etc/devicetree/custom-device.dtbo > /sys/kernel/config/device-tree/overlays/custom-device/dtbo
+cat /sys/kernel/config/device-tree/overlays/custom-device/status   # expect: applied
 ```
 
 Check dmesg for any errors:

--- a/docs/DS3231-RTC.md
+++ b/docs/DS3231-RTC.md
@@ -27,17 +27,14 @@ To enable the DS3231 RTC at runtime (will not persist across reboots):
 # Create overlay directory
 mkdir -p /sys/kernel/config/device-tree/overlays/ds3231
 
-# Load the overlay
+# Write the overlay (kernel applies on this write; status is read-only)
 cat /boot/devicetree/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo
-
-# Apply the overlay
-echo 1 > /sys/kernel/config/device-tree/overlays/ds3231/status
+cat /sys/kernel/config/device-tree/overlays/ds3231/status   # expect: applied
 ```
 
 To remove the overlay:
 
 ```bash
-echo 0 > /sys/kernel/config/device-tree/overlays/ds3231/status
 rmdir /sys/kernel/config/device-tree/overlays/ds3231
 ```
 
@@ -57,9 +54,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c 'mkdir -p /sys/kernel/config/device-tree/overlays/ds3231 && \
   cat /boot/devicetree/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo && \
-  echo 1 > /sys/kernel/config/device-tree/overlays/ds3231/status'
-ExecStop=/bin/sh -c 'echo 0 > /sys/kernel/config/device-tree/overlays/ds3231/status; \
-  rmdir /sys/kernel/config/device-tree/overlays/ds3231'
+  [ "$(cat /sys/kernel/config/device-tree/overlays/ds3231/status)" = applied ]'
+ExecStop=/bin/sh -c 'rmdir /sys/kernel/config/device-tree/overlays/ds3231'
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/DS3231-RTC.md
+++ b/docs/DS3231-RTC.md
@@ -16,7 +16,8 @@ The default I2C address for DS3231 is **0x68**.
 
 ## Enabling the DS3231 Overlay
 
-The compiled overlay is installed to `/lib/firmware/overlays/ds3231-rtc.dtbo`.
+The compiled overlay is installed to `/boot/devicetree/ds3231-rtc.dtbo`.
+For a persistent enable, add `ds3231-rtc` to `/etc/device-tree-overlays.conf` and reboot.
 
 ### Method 1: Runtime via ConfigFS (Temporary)
 
@@ -27,7 +28,7 @@ To enable the DS3231 RTC at runtime (will not persist across reboots):
 mkdir -p /sys/kernel/config/device-tree/overlays/ds3231
 
 # Load the overlay
-cat /lib/firmware/overlays/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo
+cat /boot/devicetree/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo
 
 # Apply the overlay
 echo 1 > /sys/kernel/config/device-tree/overlays/ds3231/status
@@ -55,7 +56,7 @@ Requires=sys-kernel-config.mount
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c 'mkdir -p /sys/kernel/config/device-tree/overlays/ds3231 && \
-  cat /lib/firmware/overlays/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo && \
+  cat /boot/devicetree/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo && \
   echo 1 > /sys/kernel/config/device-tree/overlays/ds3231/status'
 ExecStop=/bin/sh -c 'echo 0 > /sys/kernel/config/device-tree/overlays/ds3231/status; \
   rmdir /sys/kernel/config/device-tree/overlays/ds3231'

--- a/docs/NEO-M8N-GPS.md
+++ b/docs/NEO-M8N-GPS.md
@@ -29,17 +29,14 @@ To enable the NEO-M8N GPS at runtime (will not persist across reboots):
 # Create overlay directory
 mkdir -p /sys/kernel/config/device-tree/overlays/neo-m8n
 
-# Load the overlay
+# Write the overlay (kernel applies on this write; status is read-only)
 cat /boot/devicetree/neo-m8n-gps.dtbo > /sys/kernel/config/device-tree/overlays/neo-m8n/dtbo
-
-# Apply the overlay
-echo 1 > /sys/kernel/config/device-tree/overlays/neo-m8n/status
+cat /sys/kernel/config/device-tree/overlays/neo-m8n/status   # expect: applied
 ```
 
 To remove the overlay:
 
 ```bash
-echo 0 > /sys/kernel/config/device-tree/overlays/neo-m8n/status
 rmdir /sys/kernel/config/device-tree/overlays/neo-m8n
 ```
 
@@ -59,9 +56,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c 'mkdir -p /sys/kernel/config/device-tree/overlays/neo-m8n && \
   cat /boot/devicetree/neo-m8n-gps.dtbo > /sys/kernel/config/device-tree/overlays/neo-m8n/dtbo && \
-  echo 1 > /sys/kernel/config/device-tree/overlays/neo-m8n/status'
-ExecStop=/bin/sh -c 'echo 0 > /sys/kernel/config/device-tree/overlays/neo-m8n/status; \
-  rmdir /sys/kernel/config/device-tree/overlays/neo-m8n'
+  [ "$(cat /sys/kernel/config/device-tree/overlays/neo-m8n/status)" = applied ]'
+ExecStop=/bin/sh -c 'rmdir /sys/kernel/config/device-tree/overlays/neo-m8n'
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/NEO-M8N-GPS.md
+++ b/docs/NEO-M8N-GPS.md
@@ -1,0 +1,227 @@
+# u-blox NEO-M8N GPS Module Support
+
+Calculinux includes support for the u-blox NEO-M8N GPS module via a device tree overlay that enables UART5 communication.
+
+## Hardware Connection
+
+The NEO-M8N module connects to **UART5** on the PicoCalc RMII1 test pads:
+
+- **VCC**: 3.3V power
+- **GND**: Ground
+- **TX**: UART5_RX (GPIO3_B3, Pin 29) - GPS transmits data to PicoCalc
+- **RX**: UART5_TX (GPIO3_B4, Pin 28) - PicoCalc transmits commands to GPS
+- **PPS** (Optional): Pulse-per-second signal for high-precision time sync - can be connected to a GPIO pin
+
+> **Note**: The NEO-M8N TX connects to the PicoCalc RX, and NEO-M8N RX connects to PicoCalc TX.
+
+The NEO-M8N defaults to **9600 baud** but can be configured up to 230400 baud using u-center or NMEA commands.
+
+## Enabling the NEO-M8N Overlay
+
+The compiled overlay is installed to `/boot/devicetree/neo-m8n-gps.dtbo`.
+For a persistent enable, add `neo-m8n-gps` to `/etc/device-tree-overlays.conf` and reboot.
+
+### Method 1: Runtime via ConfigFS (Temporary)
+
+To enable the NEO-M8N GPS at runtime (will not persist across reboots):
+
+```bash
+# Create overlay directory
+mkdir -p /sys/kernel/config/device-tree/overlays/neo-m8n
+
+# Load the overlay
+cat /boot/devicetree/neo-m8n-gps.dtbo > /sys/kernel/config/device-tree/overlays/neo-m8n/dtbo
+
+# Apply the overlay
+echo 1 > /sys/kernel/config/device-tree/overlays/neo-m8n/status
+```
+
+To remove the overlay:
+
+```bash
+echo 0 > /sys/kernel/config/device-tree/overlays/neo-m8n/status
+rmdir /sys/kernel/config/device-tree/overlays/neo-m8n
+```
+
+### Method 2: Systemd Service (Persistent)
+
+To automatically load the overlay at boot, create a systemd service:
+
+```bash
+cat > /etc/systemd/system/neo-m8n-gps.service << 'EOF'
+[Unit]
+Description=Load NEO-M8N GPS device tree overlay
+After=sys-kernel-config.mount
+Requires=sys-kernel-config.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'mkdir -p /sys/kernel/config/device-tree/overlays/neo-m8n && \
+  cat /boot/devicetree/neo-m8n-gps.dtbo > /sys/kernel/config/device-tree/overlays/neo-m8n/dtbo && \
+  echo 1 > /sys/kernel/config/device-tree/overlays/neo-m8n/status'
+ExecStop=/bin/sh -c 'echo 0 > /sys/kernel/config/device-tree/overlays/neo-m8n/status; \
+  rmdir /sys/kernel/config/device-tree/overlays/neo-m8n'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable neo-m8n-gps.service
+systemctl start neo-m8n-gps.service
+```
+
+## Verifying the GPS Connection
+
+After loading the overlay, verify UART5 is available:
+
+```bash
+# Check serial device
+ls -l /dev/ttyS5
+
+# Check kernel messages
+dmesg | grep uart5
+dmesg | grep ttyS5
+```
+
+## Reading GPS Data
+
+### Raw NMEA Sentences
+
+To read raw NMEA sentences from the GPS:
+
+```bash
+# Read continuous GPS data
+cat /dev/ttyS5
+
+# Read with stty configuration
+stty -F /dev/ttyS5 9600 raw
+cat /dev/ttyS5
+```
+
+Example NMEA output:
+```
+$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47
+$GPGSA,A,3,04,05,,09,12,,,24,,,,,2.5,1.3,2.1*39
+$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A
+```
+
+### Using gpsd
+
+Install and configure `gpsd` for easier GPS access:
+
+```bash
+# Install gpsd (if not already installed)
+opkg update
+opkg install gpsd gpsd-clients
+
+# Start gpsd
+gpsd /dev/ttyS5 -F /var/run/gpsd.sock
+
+# Monitor GPS status
+gpsmon /dev/ttyS5
+
+# Or use cgps for a simpler display
+cgps
+```
+
+### Using gpsmon/cgps without gpsd daemon
+
+You can directly monitor the GPS without running the gpsd daemon:
+
+```bash
+gpsmon /dev/ttyS5
+```
+
+## GPS Applications
+
+### Time Synchronization
+
+Use the GPS for NTP time synchronization:
+
+```bash
+# Install gpsd and gpsd-clients
+opkg install gpsd gpsd-clients
+
+# Configure chronyd or ntpd to use GPS as a time source
+# (Refer to Calculinux time sync documentation)
+```
+
+### Location Services
+
+The GPS can be used with applications that support NMEA or gpsd:
+- Navigation applications
+- Geocaching tools
+- Location logging
+- Meshtastic with GPS positioning (when used alongside LoRA module)
+
+## Troubleshooting
+
+### No data from GPS
+
+1. **Check connections**: Ensure TX/RX are not swapped
+2. **Check baud rate**: Default is 9600, verify with:
+   ```bash
+   stty -F /dev/ttyS5
+   ```
+3. **Check GPS power**: Module requires 3.3V
+4. **Wait for satellite fix**: GPS may take 30-60 seconds for first fix (cold start)
+
+### GPS not detected
+
+```bash
+# Verify overlay is loaded
+ls /sys/kernel/config/device-tree/overlays/neo-m8n/
+
+# Check if UART5 is enabled in device tree
+ls -l /dev/ttyS5
+
+# Check kernel messages
+dmesg | grep -i uart
+```
+
+### Adjusting Baud Rate
+
+To change the GPS baud rate (requires sending UBX configuration commands):
+
+```bash
+# Install u-blox u-center or use NMEA commands
+# Example NMEA command to set 115200 baud:
+echo '$PUBX,41,1,0007,0003,115200,0*18' > /dev/ttyS5
+
+# Then reconfigure the serial port:
+stty -F /dev/ttyS5 115200
+```
+
+## Hardware Considerations
+
+### Antenna
+
+The NEO-M8N requires an external active or passive GPS antenna:
+- **Active antenna**: Requires power (3.3V via module's ANT_PWR)
+- **Passive antenna**: No power needed but lower sensitivity
+
+### Power Consumption
+
+- Active mode: ~23 mA @ 3.3V
+- Power save mode: ~11 mA (configurable via UBX protocol)
+- Backup mode: ~15 µA (requires backup battery on V_BKUP pin)
+
+## Compatibility with LoRA Module
+
+The NEO-M8N GPS overlay is designed to work alongside the SX1262 LoRA module overlay. The LoRA module uses UART5_CTSN and UART5_RTSN pins (which are not needed for GPS), while the GPS uses UART5_TX and UART5_RX.
+
+**Both overlays can be loaded simultaneously** to enable GPS-equipped Meshtastic functionality.
+
+## Device Tree Overlay Source
+
+The overlay source is located in the `picocalc-drivers` repository:
+- Path: `luckfox-lyra/overlays/neo-m8n-gps-overlay.dts`
+- Compiled to: `/boot/devicetree/neo-m8n-gps.dtbo`
+
+## Additional Resources
+
+- [u-blox NEO-M8 Datasheet](https://www.u-blox.com/en/product/neo-m8-series)
+- [NMEA Protocol Reference](http://www.gpsinformation.org/dale/nmea.htm)
+- [gpsd Documentation](https://gpsd.gitlab.io/gpsd/)
+- [u-center Configuration Software](https://www.u-blox.com/en/product/u-center) (Windows only)

--- a/docs/PCM5102A-I2S-DAC.md
+++ b/docs/PCM5102A-I2S-DAC.md
@@ -1,0 +1,149 @@
+# PCM5102A I2S DAC for PicoCalc Audio
+
+## Hardware Shopping List
+
+### PCM5102A DAC Module
+**Recommended:** GY-PCM5102 breakout board
+- **Price:** ~$1.50-3.00 USD  
+- **Where to buy:** AliExpress, eBay
+- **Search terms:** "PCM5102 GY-PCM5102", "PCM5102A I2S DAC"
+- **Specifications:**
+  - 24-bit/192kHz capable
+  - Stereo output (Left + Right channels)
+  - 3.3V compatible
+  - No configuration needed (hardware mode)
+
+## Pin Connections
+
+### Lyra → PCM5102A Wiring
+
+| Lyra Pin | Lyra Signal | Pin Location | PCM5102A Pin | Function |
+|----------|-------------|--------------|--------------|----------|
+| 33 | GPIO3_A7 (SAI2_SCLK_M0) | RMII1_RXD1 test pad | BCK | Bit Clock |
+| 32 | GPIO3_B0 (SAI2_SDO_M0) | RMII1_CLK test pad | DIN | Data Input |
+| 31 | GPIO3_B1 (SAI2_LRCK_M0) | RMII1_TXD0 test pad | LCK | Left/Right Clock |
+| 26 | GPIO3_B6 (SAI2_MCLK_M0) | RMII1_RXDVCRS test pad | SCK | Master Clock (optional) |
+| 3.3V | Power | Any 3.3V pad | VIN/VCC | Power Supply |
+| GND | Ground | Any GND pad | GND | Ground |
+
+### PCM5102A Module Configuration
+
+**Required jumpers/connections on GY-PCM5102 module:**
+- **FLT** → GND (normal filter latency)
+- **DEMP** → GND (de-emphasis off)  
+- **XSMT** → 3.3V (soft mute off)
+- **FMT** → GND (I2S format)
+- **H1L**, **H2L**, **H3L**, **H4L** → All LOW (3.3V system, I2S format)
+
+**Optional:**
+- **SCK** (master clock) can be left disconnected - PCM5102A will work fine without it. Leave it disconnected if you also use the SX1262 overlay (DIO1 is GPIO3_B6).
+- If your module doesn't have these jumpers, it likely runs in fixed hardware mode (which is perfect)
+
+### Output Connections
+
+The PCM5102A has stereo line-level outputs:
+- **LOUT** → Connect to Left channel of your existing audio circuit (where filtered PWM left goes)
+- **ROUT** → Connect to Right channel of your existing audio circuit (where filtered PWM right goes)
+- **AGND** → Audio ground reference
+
+**Integration with existing PicoCalc audio:**
+- Disconnect or disable the PWM audio signals
+- Connect DAC outputs to the same point where the **filtered PWM** signals currently feed
+- The DAC output is already analog, so it bypasses the PWM low-pass filter
+- Connect directly to the amplifier input or headphone jack
+
+## Software Setup
+
+### 1. Device Tree Overlay
+The overlay has been created at:
+```
+picocalc-drivers/luckfox-lyra/overlays/pcm5102a-i2s-overlay.dts
+```
+
+### 2. Kernel Configuration
+The kernel config fragment has been added:
+```
+meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/audio-i2s.cfg
+```
+
+This enables:
+- `CONFIG_SND_SOC_PCM5102A=y` (codec driver)
+- `CONFIG_SND_SIMPLE_CARD=y` (simple audio card framework)
+- `CONFIG_SND_SOC_ROCKCHIP_SAI=y` (already enabled)
+
+### 3. Build and Deploy
+```bash
+# From calculinux-build/ directory
+./meta-calculinux/kas-container build ./meta-calculinux/kas-luckfox-lyra-bundle.yaml
+
+# Flash updated image to device
+# Copy overlay to device: /boot/devicetree/pcm5102a-i2s.dtbo
+```
+
+### 4. Enable Overlay
+
+Add `pcm5102a-i2s` to `/etc/device-tree-overlays.conf` and reboot.
+
+To apply at runtime instead:
+```bash
+# On the PicoCalc device:
+mkdir -p /sys/kernel/config/device-tree/overlays/pcm5102a
+cat /boot/devicetree/pcm5102a-i2s.dtbo > \
+    /sys/kernel/config/device-tree/overlays/pcm5102a/dtbo
+echo 1 > /sys/kernel/config/device-tree/overlays/pcm5102a/status
+```
+
+### 5. Verify Audio Device
+```bash
+# Check sound card appeared
+aplay -l
+
+# Test stereo output
+speaker-test -D hw:0,0 -c 2 -t sine
+```
+
+## Benefits Over PWM Audio
+
+1. **Zero CPU overhead** - Hardware I2S controller handles everything
+2. **Much better audio quality** - True 24-bit DAC vs software PWM
+3. **No PWM noise** - Clean analog output, no high-frequency carrier
+4. **Stereo support** - Left and Right channels properly separated
+5. **Standard ALSA interface** - Works with any Linux audio software
+
+## Troubleshooting
+
+### No sound output
+- Check all wire connections
+- Verify overlay loaded: `ls /sys/kernel/config/device-tree/overlays/`
+- Check kernel log: `dmesg | grep -i "pcm5102\|sai2"`
+- Verify sound card: `cat /proc/asound/cards`
+
+### Distorted or noisy audio
+- Check VCC is stable 3.3V
+- Ensure good ground connection
+- Verify pin functions are correct (not still configured as GPIO)
+- Check format jumpers on PCM5102A module
+
+### One channel missing
+- Verify LCK (LRCK) connection
+- Check both LOUT and ROUT wiring
+- Test with: `speaker-test -D hw:0,0 -c 2 -t wav`
+
+## Technical Notes
+
+### About SAI2_MCLK (Master Clock)
+- The PCM5102A can operate without master clock in "slave mode"
+- MCLK is typically 256× the sample rate (e.g., 12.288 MHz for 48 kHz audio)
+- The Lyra's SAI2 controller can generate MCLK automatically if needed
+- For simplest setup, leave MCLK/SCK unconnected initially
+
+### Sample Rates
+The SAI2 controller supports:
+- 8 kHz to 192 kHz sample rates
+- 16-bit, 24-bit, 32-bit sample depths
+- I2S, Left-Justified, Right-Justified formats
+
+### Power Consumption
+- PCM5102A: ~10mA typical
+- Much lower than CPU overhead from software PWM
+- Can be powered directly from Lyra 3.3V rail

--- a/docs/PCM5102A-I2S-DAC.md
+++ b/docs/PCM5102A-I2S-DAC.md
@@ -90,7 +90,7 @@ To apply at runtime instead:
 mkdir -p /sys/kernel/config/device-tree/overlays/pcm5102a
 cat /boot/devicetree/pcm5102a-i2s.dtbo > \
     /sys/kernel/config/device-tree/overlays/pcm5102a/dtbo
-echo 1 > /sys/kernel/config/device-tree/overlays/pcm5102a/status
+cat /sys/kernel/config/device-tree/overlays/pcm5102a/status   # expect: applied
 ```
 
 ### 5. Verify Audio Device

--- a/docs/SX1262-LORA-MESHTASTIC.md
+++ b/docs/SX1262-LORA-MESHTASTIC.md
@@ -1,0 +1,240 @@
+# Waveshare SX1262HF LoRA Module for PicoCalc + Meshtastic
+
+## Hardware Setup
+
+### Module: Waveshare Core1262-868M SX1262HF
+- **Frequency**: 868 MHz (also available: 433 MHz, 915 MHz)
+- **Power**: 3.3V @ ~50mA active
+- **SPI Interface**: Up to 10 MHz (will use 2 MHz bitbang)
+- **Datasheet**: https://www.waveshare.com/wiki/Core1262-868M
+
+### Pin Connections
+
+```
+PicoCalc Lyra              SX1262 Module
+────────────────────────────────────────
+GPIO3_B2 (Pin 30)  →  CLK
+GPIO3_B5 (Pin 27)  →  MOSI
+GPIO3_A6           →  MISO
+GPIO3_B6 (Pin 26)  →  DIO1
+GPIO1_D0 (Pin 115) →  BUSY
+GND                →  CS
+3.3V               →  VCC + RESET pullup
+```
+
+### RESET Pin Handling
+
+**The SX1262 has an active-low RESET pin, and you're tying it HIGH permanently.**
+
+This is a valid approach because:
+1. The module has internal pull-ups on RESET
+2. Meshtastic doesn't need to perform hardware reset on startup
+3. Software initialization resets the module state via SPI commands
+4. It saves one GPIO pin
+
+**Circuit:**
+```
+3.3V ──[10kΩ]── RESET pin (SX1262)
+```
+
+The 10kΩ resistor is optional but recommended to limit current if the pin is accidentally driven low.
+
+### RF Switch Control
+
+The SX1262 module includes automatic RF switching. Configuration:
+- **DIO2_AS_RF_SWITCH: true** in Meshtastic config enables internal control
+- **DIO2** pin controls the switch mode (optional hardware control)
+- Tie **RXEN** and **TXEN** to GND for default RX mode, or control via DIO2
+
+## Bitbang SPI Performance
+
+### Why Software SPI Works
+
+| Metric | Value | Impact |
+|--------|-------|--------|
+| ARM CPU Clock | 100 MHz | Fast GPIO toggle |
+| Target SPI Speed | 2 MHz | Bitbang capable |
+| LoRA Air Interface | ~1 second | SPI not the bottleneck |
+| Data Rate | 50 kbps max | Plenty of margin |
+
+**Calculation:** At 100 MHz CPU, minimum GPIO toggle time is ~10 ns. A 2 MHz SPI clock needs 250 ns per bit-period, which is achievable with ample headroom for software overhead.
+
+### Performance Expectations
+
+- **SPI Throughput**: ~2 Mbps (bitbang at 2 MHz, 1 data bit per clock)
+- **Typical SPI Transaction**: 50-100 bytes @ 2 MHz = 200-400 microseconds
+- **Meshtastic Operation**: Fully functional, no noticeable lag
+- **Real-world Bottleneck**: LoRA air interface (1-10 second packet times)
+
+## Meshtastic Configuration
+
+Shipped config (enable by linking into `/etc/meshtasticd/config.d/`):
+- **File**: `meta-meshtastic/recipes-connectivity/meshtasticd/files/available.d/lora-lyra-picocalc-waveshare-sx1262.yaml`
+- **On device**: `/etc/meshtasticd/available.d/lora-lyra-picocalc-waveshare-sx1262.yaml`
+- **SPI Method**: GPIO bitbang (`spidev2.0` from the `sx1262-lora` overlay)
+- **Speed**: 2 MHz
+- **RF Switch**: Automatic (`DIO2_AS_RF_SWITCH: true`); CS and RESET tied (config `-1`)
+
+### GPIO Mapping (matches the shipped YAML)
+
+`gpiochip` 3 is bank 3; line = group*8+X (A=0, B=1, …). Busy is on gpiochip 1.
+
+| Pin | yaml | Function |
+|-----|------|----------|
+| GPIO3_B2 | gpiochip 3, CLK: 10 | SPI Clock |
+| GPIO3_B5 | gpiochip 3, MOSI: 13 | SPI MOSI |
+| GPIO3_A6 | gpiochip 3, MISO: 6 | SPI MISO |
+| GPIO3_B6 | gpiochip 3, IRQ: 14 | DIO1 |
+| GPIO1_D0 | gpiochip 1, Busy line: 24 | Busy |
+
+## Assembly Instructions
+
+### 1. Prepare the Module
+
+```bash
+# Check module orientation - antenna connector should face outward
+# Verify all pins are straight and not bent
+```
+
+### 2. Solder Test Pad Connections
+
+Wire the 6 signal pins to the test pads:
+- Use 24-28 AWG wire for reliability
+- Keep traces short (under 5cm if possible)
+- Twist CLK + MOSI together (reduce EMI)
+- Separate MISO from CLK/MOSI if possible
+
+### 3. RESET Pullup (Important!)
+
+On the SX1262 module, locate the RESET pin and connect:
+```
+[RESET pin] ──[10kΩ]── [3.3V test pad]
+           ││
+           └─ Leave floating or this risks brownouts
+```
+
+### 4. Chip Select
+
+**Option A (Recommended):** Permanently tie CS to GND
+```
+[CS pin] ── [GND test pad]  (solder directly)
+```
+
+**Option B:** Use GPIO (uses extra pin)
+- If you want CS controlled by software later, don't ground it
+- Wire CS to a free GPIO and set `CS:` in the YAML (do not reuse CLK GPIO3_B2)
+
+### 5. Power and Ground
+
+- Connect **VCC** to any **3.3V test pad**
+- Connect **GND** to any **GND test pad** (multiple connections recommended)
+- Add **10µF decoupling capacitor** near VCC pin
+
+### 6. RF Connections
+
+- **Antenna**: Connect to ANT connector
+- **RXEN**: Tie to GND (RX default)
+- **TXEN**: Tie to GND (or control via GPIO if desired)
+- **DIO2**: Module-internal RF switch (`DIO2_AS_RF_SWITCH`); GPIO1_D0 is Busy, not DIO2
+
+## Software Setup
+
+### 1. Build with Meshtastic Support
+
+```bash
+cd calculinux-build
+./meta-calculinux/kas-container build ./meta-calculinux/kas-luckfox-lyra-bundle.yaml
+```
+
+### 2. Deploy Device Tree Overlay
+
+The overlay should be compiled and installed in the image:
+```
+/boot/devicetree/sx1262-lora.dtbo
+```
+
+### 3. Enable Overlay (default: merged for next boot)
+
+Add `sx1262-lora` to `/etc/device-tree-overlays.conf`, then reboot. Calculinux will merge overlays
+into the boot DTB/FIT for the **next boot**.
+
+### 4. Apply Overlay at Runtime (developer option)
+
+```bash
+ssh pico@192.168.7.2
+mkdir -p /sys/kernel/config/device-tree/overlays/sx1262
+cat /boot/devicetree/sx1262-lora.dtbo > \
+    /sys/kernel/config/device-tree/overlays/sx1262/dtbo
+echo 1 > /sys/kernel/config/device-tree/overlays/sx1262/status
+```
+
+If you see `rockchip-pinctrl ... unable to find group for node sx1262-pins`, use the merged-boot workflow
+and reboot, or use the runtime-friendly overlay `sx1262-lora-runtime.dtbo`.
+
+### 4. Verify Meshtastic Operation
+
+```bash
+# Check meshtasticd is running
+systemctl status meshtasticd
+
+# Verify LoRA module is detected
+journalctl -u meshtasticd -f | grep -i "lora\|sx1262\|spi"
+
+# Check for packet reception
+meshtastic --info
+```
+
+## Troubleshooting
+
+### Module Not Detected
+
+```bash
+# Check kernel device tree
+dtc -I fs /sys/firmware/devicetree/base > /tmp/dt.dts
+grep -i "sx1262\|lora" /tmp/dt.dts
+
+# Check GPIO pins are exported
+ls -la /sys/class/gpio/ | grep gpio[0-9]
+
+# Verify Meshtastic config
+cat /etc/meshtasticd/available.d/lora-lyra-picocalc-waveshare-sx1262.yaml
+```
+
+### SPI Communication Issues
+
+```bash
+# Test SPI bitbang manually (if pins are accessible)
+cd /sys/class/gpio
+
+# Export CLK pin
+echo 106 > export
+
+# Toggle CLK to verify GPIO is functional
+echo out > gpio106/direction
+echo 1 > gpio106/value
+echo 0 > gpio106/value
+
+# If this works, SPI bitbang should work
+```
+
+### Intermittent Packet Loss
+
+- **Reduce SPI speed** (change spiSpeed to 1000000 in config)
+- **Check wiring quality** (solder joints, wire gauge)
+- **Improve antenna placement** (elevate, away from ground plane)
+- **Add shielding** if needed (wrap module in foil, keep away from power traces)
+
+### RESET Pin Issues
+
+If the module fails to initialize:
+1. Verify RESET pin is tied to 3.3V (not floating)
+2. Check for shorts to GND
+3. Measure voltage on RESET (should be ~3.3V stable)
+4. Try removing the 10kΩ resistor (use direct wire if power is stable)
+
+## References
+
+- **Waveshare Documentation**: https://www.waveshare.com/wiki/Core1262-868M
+- **SX1262 Datasheet**: Contact Semtech or check Waveshare site
+- **Meshtastic Docs**: https://meshtastic.org/
+- **GPIO Bitbang Performance**: Standard for embedded systems at 2 MHz

--- a/docs/SX1262-LORA-MESHTASTIC.md
+++ b/docs/SX1262-LORA-MESHTASTIC.md
@@ -18,7 +18,8 @@ GPIO3_B5 (Pin 27)  →  MOSI
 GPIO3_A6           →  MISO
 GPIO3_B6 (Pin 26)  →  DIO1
 GPIO1_D0 (Pin 115) →  BUSY
-GND                →  CS
+GND                →  GND
+GND                →  CS (tie CS low; or a free GPIO if you want software CS)
 3.3V               →  VCC + RESET pullup
 ```
 
@@ -68,14 +69,17 @@ The SX1262 module includes automatic RF switching. Configuration:
 
 ## Meshtastic Configuration
 
-Shipped config (enable by linking into `/etc/meshtasticd/config.d/`):
-- **File**: `meta-meshtastic/recipes-connectivity/meshtasticd/files/available.d/lora-lyra-picocalc-waveshare-sx1262.yaml`
-- **On device**: `/etc/meshtasticd/available.d/lora-lyra-picocalc-waveshare-sx1262.yaml`
+Shipped Meshtastic samples (Luckfox Pico modules, not this PicoCalc wiring) live in
+`meta-meshtastic/recipes-connectivity/meshtasticd/files/config.d/` and install to
+`/etc/meshtasticd/available.d/`. Enable a sample by linking it into `/etc/meshtasticd/config.d/`.
+
+For the Waveshare wiring above, copy a sample and edit CS/IRQ/Busy/gpiochip (or write a new
+YAML) so it matches the table below. With CS tied to GND, set `CS: -1`.
 - **SPI Method**: GPIO bitbang (`spidev2.0` from the `sx1262-lora` overlay)
 - **Speed**: 2 MHz
 - **RF Switch**: Automatic (`DIO2_AS_RF_SWITCH: true`); CS and RESET tied (config `-1`)
 
-### GPIO Mapping (matches the shipped YAML)
+### GPIO Mapping (for the wiring above)
 
 `gpiochip` 3 is bank 3; line = group*8+X (A=0, B=1, …). Busy is on gpiochip 1.
 
@@ -165,7 +169,7 @@ ssh pico@192.168.7.2
 mkdir -p /sys/kernel/config/device-tree/overlays/sx1262
 cat /boot/devicetree/sx1262-lora.dtbo > \
     /sys/kernel/config/device-tree/overlays/sx1262/dtbo
-echo 1 > /sys/kernel/config/device-tree/overlays/sx1262/status
+cat /sys/kernel/config/device-tree/overlays/sx1262/status   # expect: applied
 ```
 
 If you see `rockchip-pinctrl ... unable to find group for node sx1262-pins`, use the merged-boot workflow
@@ -196,8 +200,9 @@ grep -i "sx1262\|lora" /tmp/dt.dts
 # Check GPIO pins are exported
 ls -la /sys/class/gpio/ | grep gpio[0-9]
 
-# Verify Meshtastic config
-cat /etc/meshtasticd/available.d/lora-lyra-picocalc-waveshare-sx1262.yaml
+# Verify Meshtastic config (edit a sample from available.d to match this wiring)
+ls /etc/meshtasticd/available.d/
+ls /etc/meshtasticd/config.d/
 ```
 
 ### SPI Communication Issues


### PR DESCRIPTION
## Summary
- Update overlay docs for merge-at-boot, `/boot/devicetree`, and the PicoCalc SX1262 YAML pin map.
- Add PCM5102A and NEO-M8N guides; fix DS3231/README overlay paths.

## Test plan
- [ ] Follow each hardware doc against an image from #147.
- [ ] No remaining `/lib/firmware/overlays` or deleted Meshtastic `config.d` paths.

Split from #114 (slice 5/5). **Base is #147** — merge that first.


Made with [Cursor](https://cursor.com)