### PR TITLE
Fix rtl8xxxu 8188EU first-probe scan and stop iwd using WPA3 on it

### DIFF
--- a/meta-calculinux-distro/recipes-connectivity/iwd/files/main.conf
+++ b/meta-calculinux-distro/recipes-connectivity/iwd/files/main.conf
@@ -1,0 +1,12 @@
+[General]
+EnableNetworkConfiguration=true
+# iwd 3.5+ wants a driver list here. The old [Security] DisableSAE=true is ignored,
+# so rtl8xxxu was still doing WPA3/SAE (auth status 77, software MFP).
+SaeDisable=rtl8xxxu,aic8800*
+PowerSaveDisable=rtl8xxxu
+
+[Network]
+NameResolvingService=systemd
+
+[Scan]
+DisablePeriodicScan=false

--- a/meta-calculinux-distro/recipes-connectivity/iwd/iwd_%.bbappend
+++ b/meta-calculinux-distro/recipes-connectivity/iwd/iwd_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " file://main.conf"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/iwd
+    install -m 0644 ${UNPACKDIR}/main.conf ${D}${sysconfdir}/iwd/main.conf
+}
+
+CONFFILES:${PN} += "${sysconfdir}/iwd/main.conf"

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8188eu-needs-full-init.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8188eu-needs-full-init.patch
@@ -1,0 +1,12 @@
+diff --git a/rtl8xxxu_8188e.c b/rtl8xxxu_8188e.c
+index 7cb5b73..8188e01 100644
+--- a/rtl8xxxu_8188e.c
++++ b/rtl8xxxu_8188e.c
+@@ -1865,6 +1865,7 @@ struct rtl8xxxu_fileops rtl8188eu_fops = {
+ 	.tx_desc_size = sizeof(struct rtl8xxxu_txdesc32),
+ 	.has_tx_report = 1,
+ 	.init_reg_pkt_life_time = 1,
++	.needs_full_init = 1,
+ 	.gen2_thermal_meter = 1,
+ 	.max_sec_cam_num = 32,
+ 	.adda_1t_init = 0x0b1b25a0,

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-retry-firmware-download.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-retry-firmware-download.patch
@@ -1,0 +1,21 @@
+diff --git a/rtl8xxxu_core.c b/rtl8xxxu_core.c
+index 7cb5b73..fwretry1 100644
+--- a/rtl8xxxu_core.c
++++ b/rtl8xxxu_core.c
+@@ -4064,8 +4064,14 @@ static int rtl8xxxu_init_device(struct ieee80211_hw *hw)
+ 	 */
+ 	rtl8xxxu_write16(priv, REG_TRXFF_BNDY + 2, fops->trxff_boundary);
+ 
+-	ret = rtl8xxxu_download_firmware(priv);
+-	dev_dbg(dev, "%s: download_firmware %i\n", __func__, ret);
++	for (int retry = 5; retry >= 0; retry--) {
++		ret = rtl8xxxu_download_firmware(priv);
++		dev_dbg(dev, "%s: download_firmware %i\n", __func__, ret);
++		if (ret != -EAGAIN)
++			break;
++		if (retry)
++			dev_dbg(dev, "%s: retry firmware download\n", __func__);
++	}
+ 	if (ret)
+ 		goto exit;
+ 	ret = rtl8xxxu_start_firmware(priv);

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/rtl8xxxu_git.bb
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/rtl8xxxu_git.bb
@@ -10,6 +10,8 @@ SRC_URI = "\
     git://github.com/aesteryck/rtl8xxxu.git;protocol=https;branch=main \
     file://rtl8188ftv-solution-d.patch \
     file://rtl8188ftv-block-size.patch \
+    file://rtl8188eu-needs-full-init.patch \
+    file://rtl8xxxu-retry-firmware-download.patch \
     "
 SRCREV = "7cb5b73796b19b460af835144e604595083ca60d"
 


### PR DESCRIPTION
First USB enum leaves the 8188EU MAC looking powered, so init skips RX enable and TX reports; rmmod only works because disconnect resets the stick. iwd 3.6 ignores DisableSAE=true and still does SAE/MFP in software.