### PR TITLE
Advertise uwific in the login MOTD

### DIFF
--- a/meta-calculinux-distro/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-calculinux-distro/recipes-core/base-files/base-files_%.bbappend
@@ -66,6 +66,7 @@ Help
   Feeds  : https://opkg.calculinux.org/
 
 Quick Commands
+  uwific
   opkg update
   opkg list
   opkg list-installed


### PR DESCRIPTION
## Summary
- Add `uwific` to the MOTD Quick Commands list so first-login users see the TUI WiFi client already in the image.

## Test plan
- [ ] Boot an image built from this branch and confirm `/etc/motd` lists `uwific` under Quick Commands
- [ ] Run `uwific` from the console as root


Made with [Cursor](https://cursor.com)