### PR TITLE
Point Yocto cache at Optane virtiofs scratch

### DIFF
--- a/.github/workflows-README.md
+++ b/.github/workflows-README.md
@@ -65,8 +65,8 @@ Sets up the Yocto build environment with cache directories and verification.
 ```yaml
 - uses: ./.github/actions/setup-build-env
   with:
-    dl-dir: ${{ github.workspace }}/../yocto-cache/downloads
-    sstate-dir: ${{ github.workspace }}/../yocto-cache/sstate-cache
+    dl-dir: /mnt/runner-cache/yocto-cache/downloads
+    sstate-dir: /mnt/runner-cache/yocto-cache/sstate-cache
     opkg-repo-dir: /mnt/opkg-repo
 ```
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ on:
 
 env:
   # Yocto build directories that need persistent storage
-  DL_DIR: ${{ github.workspace }}/../yocto-cache/downloads
-  SSTATE_DIR: ${{ github.workspace }}/../yocto-cache/sstate-cache
+  DL_DIR: /mnt/runner-cache/yocto-cache/downloads
+  SSTATE_DIR: /mnt/runner-cache/yocto-cache/sstate-cache
   # Package repository storage
   OPKG_REPO_DIR: /mnt/opkg-repo
   UPDATE_BASE_URL: https://opkg.calculinux.org

--- a/.github/workflows/cleanall.yml
+++ b/.github/workflows/cleanall.yml
@@ -35,8 +35,8 @@ on:
 
 env:
   # Yocto build directories that need persistent storage
-  DL_DIR: ${{ github.workspace }}/../yocto-cache/downloads
-  SSTATE_DIR: ${{ github.workspace }}/../yocto-cache/sstate-cache
+  DL_DIR: /mnt/runner-cache/yocto-cache/downloads
+  SSTATE_DIR: /mnt/runner-cache/yocto-cache/sstate-cache
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Move `DL_DIR` / `SSTATE_DIR` from `${{ github.workspace }}/../yocto-cache/...` (root disk under `_work`) to `/mnt/runner-cache/yocto-cache/...` on the self-hosted runners.
- Both runners share one cache tree via virtiofs → `optane/scratch/runner-cache` (~696G free on Optane).
- NFS at `/mnt/opkg-repo` stays for opkg publish only.

## Context
Root disks on VM 105/106 were ~78–79% full (~88–113G yocto cache each) while `/mnt/runner-cache` was empty. This caused build failures when the root volume filled.

## Test plan
- [ ] After current builds finish, run homelab-casc `scripts/runners/migrate-yocto-cache.sh` to merge existing caches onto virtiofs
- [ ] Trigger a build on `main`; confirm `du -sh /mnt/runner-cache/yocto-cache/*` grows and `/` usage stays flat
- [ ] Second runner job should hit shared sstate (faster rebuild)

Made with [Cursor](https://cursor.com)