### PR TITLE
Stop artifact cleanup from deleting the live .build-artifacts tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,4 +363,4 @@ jobs:
         fi
 
         # Clean up old artifacts directories (older than 7 days)
-        find /mnt/opkg-repo/.build-artifacts -maxdepth 1 -type d -mtime +7 -exec rm -rf {} \; 2>/dev/null || true
+        find /mnt/opkg-repo/.build-artifacts -mindepth 1 -maxdepth 1 -type d -mtime +7 -exec rm -rf {} \; 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Cleanup `find` now uses `-mindepth 1` so it only deletes old per-run dirs, not `/mnt/opkg-repo/.build-artifacts` itself.
- Without that, once the parent is older than 7 days, `rm -rf` wipes the current run's collect output. Publish then fails with "Shared artifacts directory not found" (run 33339093187).

## Test plan
- [ ] Merge and re-run a full build (or collect + publish). This run's artifacts are already gone.
- [ ] Confirm cleanup still removes only `*/.build-artifacts/<old-run-id>` dirs.


Made with [Cursor](https://cursor.com)