### PR TITLE
Serialize kas image pulls on shared Docker hosts

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -35,6 +35,18 @@ runs:
         fi
         echo "Package repository verified: ${{ inputs.opkg-repo-dir }}"
 
+    - name: Pre-pull kas image
+      shell: bash
+      run: |
+        # Two runners on one docker daemon (monster) race containerd if they
+        # both docker-pull kas at once: commit/rename ENOENT, exit 127.
+        ver=$(awk -F'"' '/^KAS_CONTAINER_SCRIPT_VERSION=/{print $2; exit}' kas-container)
+        img="ghcr.io/siemens/kas/kas:${ver}"
+        echo "Ensuring $img is local"
+        flock /tmp/kas-image.lock bash -c '
+          docker image inspect "$1" >/dev/null 2>&1 || docker pull "$1"
+        ' _ "$img"
+
     - name: Clean up Docker environment
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- Pre-pull `ghcr.io/siemens/kas/kas` under `flock` in setup-build-env before `kas-container` runs.
- Two monster runners share one Docker daemon; concurrent `docker pull` of kas:5.1 raced containerd (`commit failed: rename ... ingest ... no such file or directory`) and the job exited 127.
- The image is already local on monster, so a re-run works now. This stops the next cold pull (or kas tag bump) from hitting the same race.

## Test plan
- [ ] Re-run the failed job on monster (image is present).
- [ ] After merge, two matrix jobs starting together should not both pull kas.


Made with [Cursor](https://cursor.com)