### PR TITLE
Enable DS3231 RTC driver (rtc-ds1307)

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/rtc.cfg
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/rtc.cfg
@@ -1,0 +1,3 @@
+# DS3231 binds to rtc-ds1307 (maxim,ds3231). Overlay: ds3231-rtc.dtbo
+CONFIG_RTC_DRV_DS1307=m
+CONFIG_RTC_DRV_DS1307_CENTURY=y


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Enable `CONFIG_RTC_DRV_DS1307` so the existing `ds3231-rtc.dtbo` overlay can bind (`maxim,ds3231` uses the DS1307 driver).
- Kernel config fragments in `files/*.cfg` are auto-included; no recipe change.

Split from #147 so the ConfigFS overlay path and a working RTC can be tested without the merged-FIT boot pipeline. The overlay itself already ships on current images via `picocalc-dt-overlays` at `/lib/firmware/overlays/ds3231-rtc.dtbo`. It is not applied at boot.

Once this lands, #147 can drop `rtc.cfg`.

## Test plan
- [ ] Image contains `rtc-ds1307.ko` (or the driver is built in).
- [ ] After boot, ConfigFS overlay apply succeeds:

```bash
mkdir -p /sys/kernel/config/device-tree/overlays/ds3231
cat /lib/firmware/overlays/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo
echo 1 > /sys/kernel/config/device-tree/overlays/ds3231/status
cat /sys/kernel/config/device-tree/overlays/ds3231/status
```

- [ ] With a DS3231 on I2C2: `i2cdetect -y 2` shows `0x68`, `/dev/rtc1` appears, `hwclock -r -f /dev/rtc1` works.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e73f4796-163e-48ee-bd71-27c2c7bbf079?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e73f4796-163e-48ee-bd71-27c2c7bbf079&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

