### PR TITLE
Honor iwd DriverQuirks and stop networkd from owning wifi.

### DIFF
--- a/meta-calculinux-distro/recipes-connectivity/iwd/files/main.conf
+++ b/meta-calculinux-distro/recipes-connectivity/iwd/files/main.conf
@@ -1,7 +1,8 @@
 [General]
 EnableNetworkConfiguration=true
-# iwd 3.5+ wants a driver list here. The old [Security] DisableSAE=true is ignored,
-# so rtl8xxxu was still doing WPA3/SAE (auth status 77, software MFP).
+
+[DriverQuirks]
+# These keys are ignored in [General]. rtl8xxxu still did SAE (status 77).
 SaeDisable=rtl8xxxu,aic8800*
 PowerSaveDisable=rtl8xxxu
 

--- a/meta-calculinux-distro/recipes-core/systemd/files/98-wifi.link
+++ b/meta-calculinux-distro/recipes-core/systemd/files/98-wifi.link
@@ -1,5 +1,0 @@
-[Match]
-OriginalName=wl*
-
-[Link]
-Name=wlan0

--- a/meta-calculinux-distro/recipes-core/systemd/files/wlan.network
+++ b/meta-calculinux-distro/recipes-core/systemd/files/wlan.network
@@ -1,5 +1,5 @@
 [Match]
 Name=wl*
 
-[Network]
-DHCP=ipv4
+[Link]
+Unmanaged=yes

--- a/meta-calculinux-distro/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/meta-calculinux-distro/recipes-core/systemd/systemd-conf_%.bbappend
@@ -3,14 +3,12 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://journald.conf \
     file://wlan.network \
-    file://98-wifi.link \
     file://ttyblank.conf \
 "
 
 do_install() {
     install -d ${D}${systemd_unitdir}/network
     install -m 644 ${UNPACKDIR}/wlan.network ${D}${systemd_unitdir}/network
-    install -m 644 ${UNPACKDIR}/98-wifi.link ${D}${systemd_unitdir}/network
 
     install -d ${D}${systemd_unitdir}/system/getty@tty1.service.d
     install -m 0644 ${UNPACKDIR}/ttyblank.conf \


### PR DESCRIPTION
SaeDisable in [General] was ignored so rtl8xxxu still did WPA3, and wlan.network plus the forced wlan0 rename aborted the first scan.