### PR TITLE
FIT-at-boot device tree overlay merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,19 +179,8 @@ make list-images
 
 ## Device Tree Overlays
 
-The kernel is now patched with the upstream `drivers/of/configfs` implementation, so overlays can be
-managed directly through ConfigFS at runtime without building an external module:
-
-1. Make sure ConfigFS is mounted (systemd will normally handle this via `sys-kernel-config.mount`, but you
-   can do it manually with `mount -t configfs none /sys/kernel/config`).
-2. Create a directory under `/sys/kernel/config/device-tree/overlays/<name>` for each overlay you want to
-   stage.
-3. Copy the compiled overlay blob (`*.dtbo`) into the `dtbo` attribute inside that directory.
-4. Echo `1` into the matching `status` attribute to apply the overlay, or `0` to remove it again.
-
-This matches the workflow documented upstream in the `dtbocfg`/OpenWrt examples while keeping the code in-tree.
-Place reusable overlays in `/lib/firmware/overlays` (or another directory of your choosing) so
-they can be easily copied into ConfigFS when needed.
+Persistent overlays are listed in `/etc/device-tree-overlays.conf` and merged into a per-RAUC-slot FIT at boot.
+Runtime apply via ConfigFS is still available for I2C-child overlays. See [docs/DEVICE-TREE-OVERLAYS.md](docs/DEVICE-TREE-OVERLAYS.md).
 
 ---
 

--- a/docs/DEVICE-TREE-OVERLAYS.md
+++ b/docs/DEVICE-TREE-OVERLAYS.md
@@ -1,149 +1,66 @@
 # Device Tree Overlays for Calculinux
 
-Calculinux supports runtime device tree overlays using the kernel's ConfigFS interface, allowing you to enable hardware modules without rebuilding the entire image.
+Calculinux can apply overlays in two ways:
+
+- **Persistent (FIT-at-boot)**: list names in `/etc/device-tree-overlays.conf`, reboot. `merge-dt-overlays-boot` writes `/data/fit/zboot_merged_<slot>.img` for this RAUC slot. U-Boot prefers that FIT, then `/boot/zboot_merged.img`, then unmerged `zboot.img`.
+- **Runtime (ConfigFS)**: apply a `.dtbo` now. Does not persist across reboot. Works for I2C-child overlays such as DS3231. Overlays that add new pinctrl groups need the FIT path (or unused groups already in the base DTB).
+
+Compiled overlays ship in both `/boot/devicetree/` (FIT) and `/lib/firmware/overlays/` (ConfigFS). Package: `picocalc-dt-overlays`.
 
 ## Available Overlays
 
 ### DS3231 I2C RTC Module
 
-**File**: `/lib/firmware/overlays/ds3231-rtc.dtbo`  
-**Recipe**: `picocalc-dt-overlays`  
+**File**: `ds3231-rtc.dtbo`  
 **Documentation**: [DS3231-RTC.md](DS3231-RTC.md)
 
-Enables the Maxim DS3231 Real-Time Clock module on I2C bus 2.
+Enables the Maxim DS3231 Real-Time Clock on I2C bus 2.
 
 ### I2C Bus 2 @ 100 kHz
 
-**File**: `/lib/firmware/overlays/100khz-i2c.dtbo`  
-**Recipe**: `picocalc-dt-overlays`
+**File**: `100khz-i2c.dtbo`
 
 Reduces the I2C2 bus clock from 400 kHz to 100 kHz.
 
-## How Overlays Work
+## Persistent: merge for next boot
 
-Device tree overlays in Calculinux use the upstream kernel ConfigFS interface (`drivers/of/configfs`), providing a standardized way to load and unload device tree fragments at runtime without requiring external modules.
+Edit `/etc/device-tree-overlays.conf` (one name or absolute `.dtbo` path per line):
 
-### Loading an Overlay
-
-```bash
-# 1. Create overlay directory
-mkdir -p /sys/kernel/config/device-tree/overlays/<overlay-name>
-
-# 2. Load the compiled overlay
-cat /lib/firmware/overlays/<overlay-name>.dtbo > /sys/kernel/config/device-tree/overlays/<overlay-name>/dtbo
-
-# 3. Activate the overlay
-echo 1 > /sys/kernel/config/device-tree/overlays/<overlay-name>/status
+```
+ds3231-rtc
 ```
 
-### Unloading an Overlay
+Reboot. `merge-dt-overlays-boot` rebuilds this slot’s FIT on `/data`. A RAUC update deletes that slot’s merged FIT so the first boot uses `/boot/zboot_merged.img` (same kernel, no user overlays) until merge runs again.
+
+Names resolve in `/etc/devicetree/`, then `/boot/devicetree/`, then `/lib/firmware/overlays/`.
+
+Self-check (from the source tree):
 
 ```bash
-# 1. Deactivate
-echo 0 > /sys/kernel/config/device-tree/overlays/<overlay-name>/status
-
-# 2. Remove directory
-rmdir /sys/kernel/config/device-tree/overlays/<overlay-name>
+bash meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot-check.sh
 ```
 
-### Making Overlays Persistent
+## Runtime: ConfigFS
 
-Overlays loaded via ConfigFS don't persist across reboots. To load them automatically, create a systemd service (see [DS3231-RTC.md](DS3231-RTC.md) for an example).
+```bash
+mkdir -p /sys/kernel/config/device-tree/overlays/ds3231
+cat /lib/firmware/overlays/ds3231-rtc.dtbo > /sys/kernel/config/device-tree/overlays/ds3231/dtbo
+cat /sys/kernel/config/device-tree/overlays/ds3231/status
+```
+
+Writing the dtbo applies the overlay. ConfigFS apply does not persist.
 
 ## Creating New Overlays
 
-### 1. Add Overlay Source to picocalc-drivers Repository
-
-Create a `.dts` file in the [picocalc-drivers](https://github.com/Calculinux/picocalc-drivers) repository:
-
-```dts
-/dts-v1/;
-/plugin/;
-
-/* Your overlay content */
-
-&i2c2 {
-    status = "okay";
-    
-    my_device: device@addr {
-        compatible = "vendor,device";
-        reg = <0xaddr>;
-    };
-};
-```
-
-### 2. Create a Yocto Recipe
-
-Create a recipe in `meta-calculinux-distro/recipes-bsp/drivers/` like `picocalc-<device>-overlay_1.0.bb`:
-
-```bitbake
-SUMMARY = "Device tree overlay for <device>"
-LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
-
-PR = "r0"
-
-require picocalc-drivers-source.inc
-
-COMPATIBLE_MACHINE = "luckfox-lyra"
-DEPENDS = "dtc-native"
-
-do_compile() {
-    dtc -@ -I dts -O dtb -o ${B}/<overlay-name>.dtbo ${S}/<overlay-source>.dts
-}
-
-do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/overlays
-    install -m 0644 ${B}/<overlay-name>.dtbo ${D}${nonarch_base_libdir}/firmware/overlays/
-}
-
-FILES:${PN} = "${nonarch_base_libdir}/firmware/overlays/<overlay-name>.dtbo"
-PACKAGES = "${PN}"
-```
-
-### 3. Add to Image
-
-Update `kas-luckfox-lyra-bundle.yaml` to include the overlay in `PICOCALC_DRIVERS`:
-
-```yaml
-PICOCALC_DRIVERS = "\
-  picocalc-drivers-lcd-drm \
-  picocalc-drivers-snd-pwm \
-  picocalc-drivers-snd-softpwm \
-  picocalc-drivers-mfd \
-  picocalc-<device>-overlay \
-"
-```
-
-### 4. Update picocalc-drivers SRCREV
-
-After committing to picocalc-drivers, update the commit hash in `picocalc-drivers-source.inc`:
-
-```bitbake
-SRCREV = "<new-commit-hash>"
-```
-
-## Common I2C Buses
-
-The RK3506 on Luckfox Lyra has the following I2C buses available:
-
-- **I2C2**: Used for expansion (e.g., DS3231 RTC)
-  - SCL: GPIO pin IO4 (`rm_io4_i2c2_scl`)
-  - SDA: GPIO pin IO5 (`rm_io5_i2c2_sda`)
-
-Check the pinctrl configuration in device tree files for other available I2C buses.
+Add `*-overlay.dts` under `devicetree-overlays/`, `overlays/`, or `luckfox-lyra/overlays/` in [picocalc-drivers](https://github.com/Calculinux/picocalc-drivers). Put new label references in `overlays/overlay-symbols.txt`. Bump `SRCREV` in `picocalc-drivers-source.inc`. `picocalc-dt-overlays` builds all of them.
 
 ## Kernel Support
 
-The ConfigFS device tree interface is enabled via these kernel configs:
-
-- `CONFIG_OF_CONFIGFS=y`
-- `CONFIG_OF_OVERLAY=y`
-
-These are enabled in the base kernel configuration for Calculinux.
+- Selective `__symbols__` in the base DTB (kernel recipe) for ConfigFS and `fdtoverlay`
+- `CONFIG_OF_OVERLAY=y` and `CONFIG_OF_CONFIGFS=y` (`dto.cfg`)
+- ConfigFS patch: `0001-of-configfs-overlay-interface.patch`
 
 ## References
 
-- [Linux Kernel ConfigFS Device Tree Documentation](https://www.kernel.org/doc/html/latest/devicetree/overlay-notes.html)
-- [picocalc-drivers Repository](https://github.com/Calculinux/picocalc-drivers)
-- Kernel patch: `meta-picocalc-bsp-rockchip/recipes-kernel/linux/files/0001-of-configfs-overlay-interface.patch`
+- [Linux overlay notes](https://www.kernel.org/doc/html/latest/devicetree/overlay-notes.html)
+- [picocalc-drivers](https://github.com/Calculinux/picocalc-drivers)

--- a/meta-calculinux-distro/files/overlayfs-etc-preinit.sh.in
+++ b/meta-calculinux-distro/files/overlayfs-etc-preinit.sh.in
@@ -33,10 +33,14 @@ if [ "{OVERLAYFS_ETC_FSTYPE}" = "ext4" ]; then
 fi
 
 mkdir -p {OVERLAYFS_ETC_MOUNT_POINT}
-if mount -n -t {OVERLAYFS_ETC_FSTYPE} \
+DATA_MOUNTED=
+if [ -n "$PARTITION_NAME" ] && mount -n -t {OVERLAYFS_ETC_FSTYPE} \
     -o {OVERLAYFS_ETC_MOUNT_OPTIONS} \
     "/dev/$PARTITION_NAME" {OVERLAYFS_ETC_MOUNT_POINT}
 then
+    DATA_MOUNTED=1
+fi
+if [ -n "$DATA_MOUNTED" ]; then
     for overlay in $OVERLAYS; do
         echo ">> Mounting overlay for: $overlay"
 
@@ -64,6 +68,29 @@ then
             echo "PREINIT: Mounting $overlay failed!"
 
     done
+    # Drop a merged FIT whose kernel no longer matches this slot's /boot/fit_kernel
+    # (RAUC hook should already have done this; this recovers if the hook was skipped).
+    SLOT=A
+    if [ -r /proc/cmdline ]; then
+        for _arg in $(cat /proc/cmdline); do
+            [ "$_arg" = "rauc.slot=B" ] && SLOT=B
+            [ "$_arg" = "rauc.slot=A" ] && SLOT=A
+        done
+    fi
+    case "$SLOT" in B) FIT_NAME=zboot_merged_b.img ;; *) FIT_NAME=zboot_merged_a.img ;; esac
+    FIT_FILE="{OVERLAYFS_ETC_MOUNT_POINT}/fit/$FIT_NAME"
+    STAMP_FILE="{OVERLAYFS_ETC_MOUNT_POINT}/fit/kernel-${{SLOT}}.stamp"
+    if [ -f "$FIT_FILE" ] && [ -f /boot/fit_kernel ]; then
+        if [ -r /usr/lib/systemd/fit-stamp.sh ]; then
+            # shellcheck disable=SC1091
+            . /usr/lib/systemd/fit-stamp.sh
+            if stamp_should_drop /boot/fit_kernel "$STAMP_FILE"; then
+                echo "PREINIT: stale/unstamped merged FIT for slot $SLOT, removing (no reboot)"
+                rm -f "$FIT_FILE" "$STAMP_FILE"
+                sync
+            fi
+        fi
+    fi
 else
     echo "PREINIT: Mounting </data> failed!"
 fi

--- a/meta-calculinux-distro/recipes-bsp/default-merged-fit/default-merged-fit.bb
+++ b/meta-calculinux-distro/recipes-bsp/default-merged-fit/default-merged-fit.bb
@@ -1,0 +1,116 @@
+# Build a single default merged FIT (kernel + DT overlays) at image build time.
+# Uses the kernel and FDT deployed by the kernel recipe (fit_kernel, fit_fdt.dtb);
+# no extraction from zboot.img. Installs:
+#   /boot/zboot_merged.img - fallback FIT (U-Boot when both A and B on /data/fit/ fail)
+#   /boot/fit_kernel, /boot/fit_fdt.dtb, /boot/fit_compression.txt - base components
+# so merge-dt-overlays-boot.sh can build user-merged FITs from the base DTB (no extraction).
+
+SUMMARY = "Default merged zboot FIT (read-only fallback)"
+DESCRIPTION = "Builds zboot_merged.img with default device tree overlays; \
+installed in /boot/. Fallback when both A and B on /data/fit/ fail."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "luckfox-lyra"
+
+# Overlay names (without .dtbo) to apply by default. Empty = no overlays.
+# Empty: match the shipped /etc/device-tree-overlays.conf. Users add overlays
+# (e.g. sx1262-lora) to that file; merge-dt-overlays-boot applies them per slot.
+DEFAULT_DT_OVERLAYS ?= ""
+
+DEPENDS = "virtual/kernel picocalc-dt-overlays u-boot-tools-native dtc-native"
+do_install[depends] += "virtual/kernel:do_deploy"
+
+# No fetched sources; do_install only uses DEPLOY_DIR_IMAGE. Empty SRC_URI plus
+# mkdir keeps S=${UNPACKDIR} valid without a dummy file (Yocto 5.1 forbids S=${WORKDIR}).
+SRC_URI = ""
+S = "${UNPACKDIR}"
+do_unpack() {
+    mkdir -p ${UNPACKDIR}
+}
+do_patch[noexec] = "1"
+
+do_install() {
+    DEPLOY="${DEPLOY_DIR_IMAGE}"
+    KERNEL_SRC="${DEPLOY}/fit_kernel"
+    FDT_SRC="${DEPLOY}/fit_fdt.dtb"
+    COMPRESS_FILE="${DEPLOY}/fit_compression.txt"
+    OVERLAY_SRCDIR="${STAGING_DIR_TARGET}/boot/devicetree"
+    OUTDIR="${D}/boot"
+    install -d "$OUTDIR"
+
+    [ -f "$KERNEL_SRC" ] || bbfatal "default-merged-fit: $KERNEL_SRC not found (kernel must deploy fit_kernel). If using sstate, try: bitbake -c cleansstate virtual/kernel default-merged-fit"
+    [ -f "$FDT_SRC" ] || bbfatal "default-merged-fit: $FDT_SRC not found (kernel must deploy fit_fdt.dtb)"
+
+    WORKDIR_MERGE="${WORKDIR}/merge"
+    rm -rf "$WORKDIR_MERGE"
+    mkdir -p "$WORKDIR_MERGE"
+    cp "$KERNEL_SRC" "$WORKDIR_MERGE/kernel"
+    cp "$FDT_SRC" "$WORKDIR_MERGE/fdt.dtb"
+
+    COMPRESS="none"
+    [ -f "$COMPRESS_FILE" ] && COMPRESS=$(cat "$COMPRESS_FILE") || true
+
+    OVERLAY_FILES=""
+    for name in ${DEFAULT_DT_OVERLAYS}; do
+        f="$OVERLAY_SRCDIR/${name}.dtbo"
+        if [ -f "$f" ]; then
+            OVERLAY_FILES="$OVERLAY_FILES $f"
+        fi
+    done
+
+    if [ -n "$OVERLAY_FILES" ]; then
+        command -v fdtoverlay >/dev/null 2>&1 || bbfatal "fdtoverlay not found (need dtc-native with fdtoverlay)"
+        if ! fdtoverlay -i "$WORKDIR_MERGE/fdt.dtb" -o "$WORKDIR_MERGE/merged.dtb" $OVERLAY_FILES 2>"$WORKDIR_MERGE/fdtoverlay.stderr"; then
+            bbfatal "fdtoverlay failed: $(cat "$WORKDIR_MERGE/fdtoverlay.stderr" 2>/dev/null || echo 'no stderr')"
+        fi
+    else
+        cp "$WORKDIR_MERGE/fdt.dtb" "$WORKDIR_MERGE/merged.dtb"
+    fi
+
+    cat > "$WORKDIR_MERGE/image.its" << EOF
+/dts-v1/;
+/ {
+    description = "zboot with merged DTB (default)";
+    \#address-cells = <1>;
+    images {
+        kernel {
+            data = /incbin/("$WORKDIR_MERGE/kernel");
+            type = "kernel";
+            arch = "arm";
+            os = "linux";
+            compression = "$COMPRESS";
+            load = <0x00140000>;
+            entry = <0x00140000>;
+        };
+        fdt {
+            data = /incbin/("$WORKDIR_MERGE/merged.dtb");
+            type = "flat_dt";
+            arch = "arm";
+            compression = "none";
+            load = <0x00063000>;
+        };
+    };
+    configurations {
+        default = "conf";
+        conf {
+            kernel = "kernel";
+            fdt = "fdt";
+        };
+    };
+};
+EOF
+    if ! mkimage -f "$WORKDIR_MERGE/image.its" -A arm "$WORKDIR_MERGE/zboot_merged.img" -r 2>"$WORKDIR_MERGE/mkimage.stderr"; then
+        bbfatal "mkimage: failed to repack FIT: $(cat "$WORKDIR_MERGE/mkimage.stderr" 2>/dev/null || echo 'no stderr')"
+    fi
+
+    install -m 0644 "$WORKDIR_MERGE/zboot_merged.img" "$OUTDIR/zboot_merged.img"
+
+    # Base FIT components for merge-dt-overlays-boot.sh (base DTB, no overlays)
+    install -m 0644 "$WORKDIR_MERGE/kernel" "$OUTDIR/fit_kernel"
+    install -m 0644 "$WORKDIR_MERGE/fdt.dtb" "$OUTDIR/fit_fdt.dtb"
+    echo -n "$COMPRESS" > "$OUTDIR/fit_compression.txt"
+}
+
+FILES:${PN} = "/boot/zboot_merged.img /boot/fit_kernel /boot/fit_fdt.dtb /boot/fit_compression.txt"
+PACKAGES = "${PN}"

--- a/meta-calculinux-distro/recipes-bsp/drivers/picocalc-dt-overlays_1.0.bb
+++ b/meta-calculinux-distro/recipes-bsp/drivers/picocalc-dt-overlays_1.0.bb
@@ -1,5 +1,6 @@
 SUMMARY = "PicoCalc device tree overlays"
-DESCRIPTION = "Runtime device tree overlays for PicoCalc hardware"
+DESCRIPTION = "Device tree overlays for PicoCalc: ConfigFS at /lib/firmware/overlays \
+and FIT merge-at-boot at /boot/devicetree"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
@@ -11,35 +12,46 @@ COMPATIBLE_MACHINE = "luckfox-lyra"
 
 DEPENDS = "dtc-native virtual/kernel"
 
+# Skip default do_configure (oe_runmake clean) — compile uses dtc only.
+do_configure[noexec] = "1"
+do_compile[depends] += "virtual/kernel:do_shared_workdir"
+
 do_compile() {
+    # Kernel include/ only (dt-bindings). Do not add arch/.../boot/dts so
+    # labels like &i2c2 stay as __fixups__ for ConfigFS and fdtoverlay.
     KERNEL_INCLUDE="${STAGING_KERNEL_DIR}/include"
-    KERNEL_DTS_INCLUDE="${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
-    KERNEL_DTS_INCLUDE_COMMON="${KERNEL_DTS_INCLUDE}/include"
-    
-    for overlay in ${S}/devicetree-overlays/*-overlay.dts; do
-        [ -f "$overlay" ] || bbfatal "No device tree overlay sources found in ${S}/devicetree-overlays"
-        name=$(basename "$overlay" -overlay.dts)
-        
-        # Preprocess with cpp to handle #include directives
-        ${CPP} -nostdinc \
-            -I"${KERNEL_INCLUDE}" \
-            -I"${KERNEL_DTS_INCLUDE}" \
-            -I"${KERNEL_DTS_INCLUDE_COMMON}" \
-            -undef -D__DTS__ -x assembler-with-cpp \
-            "$overlay" > "${B}/${name}.pp.dts"
-        
-        # Compile preprocessed DTS to DTBO
-        dtc -@ -I dts -O dtb -o ${B}/${name}.dtbo "${B}/${name}.pp.dts"
+
+    found=0
+    for dir in ${S}/devicetree-overlays ${S}/overlays ${S}/luckfox-lyra/overlays; do
+        [ -d "$dir" ] || continue
+        for overlay in "$dir"/*-overlay.dts; do
+            [ -f "$overlay" ] || continue
+            name=$(basename "$overlay" -overlay.dts)
+
+            ${CPP} -nostdinc \
+                -I"${KERNEL_INCLUDE}" \
+                -undef -D__DTS__ -x assembler-with-cpp \
+                "$overlay" > "${B}/${name}.pp.dts"
+
+            dtc -@ -L -I dts -O dtb -o ${B}/${name}.dtbo "${B}/${name}.pp.dts"
+            found=1
+        done
     done
+    [ "$found" = 1 ] || bbfatal "No *-overlay.dts found under ${S}/{devicetree-overlays,overlays,luckfox-lyra/overlays}"
 }
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/overlays
+    install -d ${D}/boot/devicetree
     for overlay in ${B}/*.dtbo; do
         [ -f "$overlay" ] || bbfatal "No compiled overlays found in ${B}"
         install -m 0644 "$overlay" ${D}${nonarch_base_libdir}/firmware/overlays/
+        install -m 0644 "$overlay" ${D}/boot/devicetree/
     done
 }
 
-FILES:${PN} = "${nonarch_base_libdir}/firmware/overlays/*.dtbo"
+FILES:${PN} = "${nonarch_base_libdir}/firmware/overlays/*.dtbo /boot/devicetree/*.dtbo"
 PACKAGES = "${PN}"
+
+# So default-merged-fit can see overlays at image build time
+SYSROOT_DIRS += "/boot"

--- a/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
+++ b/meta-calculinux-distro/recipes-core/image/calculinux-image.bb
@@ -75,12 +75,15 @@ IMAGE_INSTALL += " \
     overlayfs-tools \
     ovl-restore \
     packagegroup-core-buildessential \
+    picocalc-dt-overlays \
     picocalc-kbd-test \
     rauc \
     sdl2-test \
     shadow \
     sudo \
     systemd-analyze \
+    default-merged-fit \
+    merge-dt-overlays-boot \
     terminus-font \
     tmux \
     tree \

--- a/meta-calculinux-distro/recipes-core/rauc/files/invalidate-merged-fit
+++ b/meta-calculinux-distro/recipes-core/rauc/files/invalidate-merged-fit
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Drop the merged FIT for the slot RAUC just installed so U-Boot boots
+# /boot/zboot_merged.img (matching kernel) until merge-dt-overlays-boot rebuilds it.
+set -e
+DATA_FIT="${DATA_FIT:-/data/fit}"
+
+invalidate() {
+    case "$1" in
+        A|a) rm -f "$DATA_FIT/zboot_merged_a.img" "$DATA_FIT/kernel-A.stamp" ;;
+        B|b) rm -f "$DATA_FIT/zboot_merged_b.img" "$DATA_FIT/kernel-B.stamp" ;;
+    esac
+}
+
+did=
+for s in ${RAUC_TARGET_SLOTS:-}; do
+    key=$(printf '%s' "$s" | tr '.' '_')
+    eval bn=\$RAUC_SLOT_BOOTNAME_$key
+    [ -z "$bn" ] && eval bn=\$RAUC_SLOT_BOOTNAME_$s
+    if [ -n "$bn" ]; then
+        invalidate "$bn"
+        did=1
+    fi
+done
+
+# Unknown slot names: drop both FITs. /boot/zboot_merged.img still boots.
+if [ -z "$did" ]; then
+    rm -f "$DATA_FIT/zboot_merged_a.img" "$DATA_FIT/zboot_merged_b.img" \
+        "$DATA_FIT/kernel-A.stamp" "$DATA_FIT/kernel-B.stamp"
+fi
+exit 0

--- a/meta-calculinux-distro/recipes-core/rauc/files/system.conf.in
+++ b/meta-calculinux-distro/recipes-core/rauc/files/system.conf.in
@@ -6,6 +6,9 @@ statusfile=/etc/rauc/rauc-slots.status
 [keyring]
 path=/etc/rauc/ca.cert.pem
 
+[handlers]
+post-install=/usr/lib/rauc/invalidate-merged-fit
+
 [slot.rootfs.0]
 device={RAUC_SLOT_A_DEVICE}
 type=ext4

--- a/meta-calculinux-distro/recipes-core/rauc/rauc-conf.bbappend
+++ b/meta-calculinux-distro/recipes-core/rauc/rauc-conf.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append := "\
                     file://system.conf.in \
+                    file://invalidate-merged-fit \
                   "
 
 RAUC_SYSTEMCONF_TEMPLATE = "${UNPACKDIR}/system.conf.in"
@@ -37,3 +38,9 @@ python do_create_system_config() {
 }
 
 addtask create_system_config after do_configure before do_install
+
+do_install:append() {
+    install -D -m 0755 ${UNPACKDIR}/invalidate-merged-fit ${D}${libdir}/rauc/invalidate-merged-fit
+}
+
+FILES:${PN} += "${libdir}/rauc/invalidate-merged-fit"

--- a/meta-calculinux-distro/recipes-core/systemd/files/clear-fit-rewritten.service
+++ b/meta-calculinux-distro/recipes-core/systemd/files/clear-fit-rewritten.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Clear U-Boot FIT failover state after successful boot
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/fw_setenv FIT_LAST_TRIED 0
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-calculinux-distro/recipes-core/systemd/files/device-tree-overlays.conf
+++ b/meta-calculinux-distro/recipes-core/systemd/files/device-tree-overlays.conf
@@ -1,0 +1,17 @@
+# List of device tree overlays to apply.
+#
+# Merge into this RAUC slot's FIT for the next boot (merge-dt-overlays-boot).
+# Nothing is enabled by default; uncomment a name below. Changes require a reboot.
+#
+# Format:
+# - one overlay per line
+# - blank lines and lines starting with # are ignored
+# - entries may be:
+#   - an overlay name (with or without .dtbo), resolved in /etc/devicetree/,
+#     /boot/devicetree/, then /lib/firmware/overlays/
+#   - an absolute path to a .dtbo file
+#
+# Examples:
+# ds3231-rtc
+# sx1262-lora
+

--- a/meta-calculinux-distro/recipes-core/systemd/files/fit-stamp.sh
+++ b/meta-calculinux-distro/recipes-core/systemd/files/fit-stamp.sh
@@ -1,0 +1,30 @@
+# Shared FIT kernel-stamp helpers (POSIX sh).
+# Sourced by merge-dt-overlays-boot.sh, preinit, and the self-check.
+#
+# stamp_should_drop KERNEL STAMP
+#   0 = drop the merged FIT (stale or unstamped)
+#   1 = keep (match, or hash unavailable — do not false-positive)
+
+fit_kernel_stamp() {
+	sha256sum "$1" | awk '{print $1}'
+}
+
+stamp_matches() {
+	[ -f "$1" ] && [ -f "$2" ] || return 1
+	[ "$(fit_kernel_stamp "$1")" = "$(cat "$2")" ]
+}
+
+# Returns 0 if the FIT should be removed, 1 if it should be kept.
+stamp_should_drop() {
+	_kernel="$1"
+	_stamp="$2"
+	[ -f "$_kernel" ] || return 1
+	_cur=$(fit_kernel_stamp "$_kernel" 2>/dev/null) || _cur=
+	# Hash failed or empty — never drop (avoids reboot/delete loops)
+	[ -n "$_cur" ] || return 1
+	# Missing stamp — untrusted FIT for next boot
+	[ -f "$_stamp" ] || return 0
+	_old=$(cat "$_stamp" 2>/dev/null) || _old=
+	[ "$_cur" = "$_old" ] && return 1
+	return 0
+}

--- a/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot-check.sh
+++ b/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot-check.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Self-check for RAUC-slot FIT naming, stamp policy, and invalidate-merged-fit.
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=merge-dt-overlays-boot.sh
+MERGE_DT_OVERLAYS_LIB=1
+# The helper file is a bash script; `.` needs bash functions.
+. "$DIR/merge-dt-overlays-boot.sh"
+
+assert_eq() {
+    [ "$1" = "$2" ] || { echo "FAIL: expected '$2' got '$1' ($3)" >&2; exit 1; }
+}
+
+assert_ok() {
+    "$@" || { echo "FAIL: expected success: $*" >&2; exit 1; }
+}
+
+assert_fail() {
+    if "$@"; then
+        echo "FAIL: expected failure: $*" >&2
+        exit 1
+    fi
+}
+
+assert_eq "$(resolve_rauc_slot A '')" A "explicit A"
+assert_eq "$(resolve_rauc_slot b '')" B "explicit b"
+assert_eq "$(resolve_rauc_slot '' 'console=tty rauc.slot=B quiet')" B "cmdline B"
+assert_eq "$(resolve_rauc_slot '' 'rauc.slot=A')" A "cmdline A"
+assert_eq "$(resolve_rauc_slot '' '')" A "default A"
+assert_eq "$(resolve_rauc_slot A 'rauc.slot=B')" A "explicit wins over cmdline"
+assert_eq "$(merged_fit_name B '')" zboot_merged_b.img "name B"
+assert_eq "$(merged_fit_name A '')" zboot_merged_a.img "name A"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+printf 'kernel\n' > "$tmpdir/k"
+fit_kernel_stamp "$tmpdir/k" > "$tmpdir/s"
+stamp_matches "$tmpdir/k" "$tmpdir/s" || { echo "FAIL: matching stamp" >&2; exit 1; }
+printf 'other\n' > "$tmpdir/k2"
+if stamp_matches "$tmpdir/k2" "$tmpdir/s"; then
+    echo "FAIL: stamp should not match a different kernel" >&2
+    exit 1
+fi
+
+# stamp_should_drop: match → keep (nonzero)
+assert_fail stamp_should_drop "$tmpdir/k" "$tmpdir/s"
+# mismatch → drop
+assert_ok stamp_should_drop "$tmpdir/k2" "$tmpdir/s"
+# missing stamp → drop
+assert_ok stamp_should_drop "$tmpdir/k" "$tmpdir/missing.stamp"
+# empty hash (nonexistent kernel) → keep (do not false-positive)
+assert_fail stamp_should_drop "$tmpdir/no-such-kernel" "$tmpdir/s"
+
+# invalidate-merged-fit: slot A via rootfs.0 / bootname env
+INVALIDATE="$DIR/../../rauc/files/invalidate-merged-fit"
+if [ ! -x "$INVALIDATE" ] && [ -f "$INVALIDATE" ]; then
+    chmod +x "$INVALIDATE"
+fi
+if [ -f "$INVALIDATE" ]; then
+    mkdir -p "$tmpdir/fit"
+    touch "$tmpdir/fit/zboot_merged_a.img" "$tmpdir/fit/kernel-A.stamp" \
+        "$tmpdir/fit/zboot_merged_b.img" "$tmpdir/fit/kernel-B.stamp"
+    RAUC_TARGET_SLOTS=rootfs.0 \
+        RAUC_SLOT_BOOTNAME_rootfs_0=A \
+        DATA_FIT="$tmpdir/fit" \
+        "$INVALIDATE"
+    [ ! -e "$tmpdir/fit/zboot_merged_a.img" ] || { echo "FAIL: A FIT should be removed" >&2; exit 1; }
+    [ ! -e "$tmpdir/fit/kernel-A.stamp" ] || { echo "FAIL: A stamp should be removed" >&2; exit 1; }
+    [ -e "$tmpdir/fit/zboot_merged_b.img" ] || { echo "FAIL: B FIT should remain" >&2; exit 1; }
+    [ -e "$tmpdir/fit/kernel-B.stamp" ] || { echo "FAIL: B stamp should remain" >&2; exit 1; }
+
+    # empty slots → drop both
+    touch "$tmpdir/fit/zboot_merged_a.img" "$tmpdir/fit/kernel-A.stamp"
+    RAUC_TARGET_SLOTS= \
+        DATA_FIT="$tmpdir/fit" \
+        "$INVALIDATE"
+    [ ! -e "$tmpdir/fit/zboot_merged_a.img" ] || { echo "FAIL: empty slots should drop A" >&2; exit 1; }
+    [ ! -e "$tmpdir/fit/zboot_merged_b.img" ] || { echo "FAIL: empty slots should drop B" >&2; exit 1; }
+else
+    echo "WARN: invalidate-merged-fit not found at $INVALIDATE, skipped" >&2
+fi
+
+echo "merge-dt-overlays-boot-check: OK"

--- a/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.path
+++ b/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.path
@@ -1,0 +1,12 @@
+[Unit]
+Description=Re-merge zboot when DT overlay config or overlays change
+After=local-fs.target
+RequiresMountsFor=/data
+
+[Path]
+PathModified=/etc/device-tree-overlays.conf
+PathModified=/etc/devicetree
+Unit=merge-dt-overlays-boot.service
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.service
+++ b/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Merge DT overlays into zboot for this RAUC slot
+After=local-fs.target
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+ConditionPathExists=/etc/device-tree-overlays.conf
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/merge-dt-overlays-boot.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.sh
+++ b/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.sh
@@ -159,8 +159,10 @@ mkimage -f image.its -A arm zboot_merged.img -r || \
     { echo "merge-dt-overlays-boot: mkimage failed to repack FIT" >&2; exit 1; }
 
 mkdir -p "$OUTPUT_DIR"
-# Atomic replace: temp then rename, then stamp (crash cannot leave torn FIT + matching stamp)
-install -m 0644 zboot_merged.img "$OUTPUT_DIR/${OUT_BASENAME}.tmp"
+# Atomic replace: temp then rename, then stamp (crash cannot leave torn FIT + matching stamp).
+# Use cp/chmod — BusyBox images often have no `install`.
+cp zboot_merged.img "$OUTPUT_DIR/${OUT_BASENAME}.tmp"
+chmod 0644 "$OUTPUT_DIR/${OUT_BASENAME}.tmp"
 mv -f "$OUTPUT_DIR/${OUT_BASENAME}.tmp" "$OUTPUT_DIR/$OUT_BASENAME"
 fit_kernel_stamp "$FIT_KERNEL" > "$STAMP_FILE"
 echo "merge-dt-overlays-boot: wrote $OUT_BASENAME for RAUC slot $SLOT (${#OVERLAY_FILES[@]} overlays)"

--- a/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.sh
+++ b/meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Merge device tree overlays into the base DTB from /boot/fit_*, then repack
+# the FIT and write to OVERLAY_DATA so U-Boot can load it at next boot.
+#
+# One merged FIT per RAUC slot: zboot_merged_a.img / zboot_merged_b.img.
+# U-Boot loads the FIT matching rauc.slot, then /boot/zboot_merged.img.
+#
+# Usage: merge-dt-overlays-boot.sh [CONFIG] [DATA_MP] [SLOT]
+#   CONFIG   default /etc/device-tree-overlays.conf
+#   DATA_MP  default /data (OVERLAY_DATA mount); output goes to $DATA_MP/fit/
+#   SLOT     A or B (default: rauc.slot= from /proc/cmdline, else A)
+
+# Load stamp helpers (fit_kernel_stamp, stamp_matches, stamp_should_drop)
+_FIT_STAMP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=fit-stamp.sh
+. "${_FIT_STAMP_DIR}/fit-stamp.sh"
+
+resolve_rauc_slot() {
+    local slot="$1"
+    local cmdline="$2"
+    case "$slot" in
+        A|a) printf '%s' A; return ;;
+        B|b) printf '%s' B; return ;;
+    esac
+    for arg in $cmdline; do
+        case "$arg" in
+            rauc.slot=A|rauc.slot=a) printf '%s' A; return ;;
+            rauc.slot=B|rauc.slot=b) printf '%s' B; return ;;
+        esac
+    done
+    printf '%s' A
+}
+
+merged_fit_name() {
+    case "$(resolve_rauc_slot "$1" "$2")" in
+        B) printf '%s' zboot_merged_b.img ;;
+        *) printf '%s' zboot_merged_a.img ;;
+    esac
+}
+
+if [ "${MERGE_DT_OVERLAYS_LIB:-}" = 1 ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+set -e
+
+CONFIG_FILE="${1:-/etc/device-tree-overlays.conf}"
+DATA_MP="${2:-/data}"
+CMDLINE=""
+[[ -r /proc/cmdline ]] && read -r CMDLINE < /proc/cmdline || true
+SLOT="$(resolve_rauc_slot "${3:-}" "$CMDLINE")"
+OUT_BASENAME="$(merged_fit_name "$SLOT" "")"
+OUTPUT_DIR="$DATA_MP/fit"
+STAMP_FILE="$OUTPUT_DIR/kernel-${SLOT}.stamp"
+
+trim() {
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+FIT_KERNEL="/boot/fit_kernel"
+FIT_FDT="/boot/fit_fdt.dtb"
+FIT_COMPRESS_FILE="/boot/fit_compression.txt"
+# Must match rk3506_common.h ENV_MEM_LAYOUT_SETTINGS
+KERNEL_LOAD_ADDR="0x00140000"
+FDT_LOAD_ADDR="0x00063000"
+
+if [[ ! -f "$FIT_KERNEL" ]] || [[ ! -f "$FIT_FDT" ]]; then
+    echo "merge-dt-overlays-boot: required $FIT_KERNEL and $FIT_FDT not found (install default-merged-fit)" >&2
+    exit 1
+fi
+
+OVERLAY_FILES=()
+if [[ -f "$CONFIG_FILE" ]]; then
+    while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+        line="${raw_line%%#*}"
+        line="$(trim "$line")"
+        [[ -z "$line" ]] && continue
+        if [[ "$line" == /* ]]; then
+            overlay_file="$line"
+        else
+            [[ "$line" != *.dtbo ]] && line="${line}.dtbo"
+            if [[ -f "/etc/devicetree/${line}" ]]; then
+                overlay_file="/etc/devicetree/${line}"
+            elif [[ -f "/boot/devicetree/${line}" ]]; then
+                overlay_file="/boot/devicetree/${line}"
+            elif [[ -f "/lib/firmware/overlays/${line}" ]]; then
+                overlay_file="/lib/firmware/overlays/${line}"
+            else
+                echo "merge-dt-overlays-boot: overlay not found: $line" >&2
+                exit 1
+            fi
+        fi
+        if [[ ! -f "$overlay_file" ]]; then
+            echo "merge-dt-overlays-boot: overlay not found: $overlay_file" >&2
+            exit 1
+        fi
+        OVERLAY_FILES+=( "$overlay_file" )
+    done < "$CONFIG_FILE"
+fi
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+cd "$WORKDIR"
+
+cp "$FIT_KERNEL" kernel
+cp "$FIT_FDT" fdt.dtb
+COMPRESS="none"
+[[ -f "$FIT_COMPRESS_FILE" ]] && read -r COMPRESS < "$FIT_COMPRESS_FILE" || true
+
+if [[ ${#OVERLAY_FILES[@]} -gt 0 ]]; then
+    if ! command -v fdtoverlay &>/dev/null; then
+        echo "merge-dt-overlays-boot: fdtoverlay not found (need dtc with fdtoverlay)" >&2
+        exit 1
+    fi
+    fdtoverlay -i fdt.dtb -o merged.dtb "${OVERLAY_FILES[@]}" || { echo "merge-dt-overlays-boot: fdtoverlay failed" >&2; exit 1; }
+else
+    cp fdt.dtb merged.dtb
+fi
+
+# Use a quoted heredoc delimiter so BitBake/shell do not mangle #address-cells.
+# load/entry must match U-Boot ram layout (rk3506_common.h).
+cat > image.its << EOF
+/dts-v1/;
+/ {
+    description = "zboot with merged DTB";
+    #address-cells = <1>;
+    images {
+        kernel {
+            data = /incbin/("kernel");
+            type = "kernel";
+            arch = "arm";
+            os = "linux";
+            compression = "$COMPRESS";
+            load = <$KERNEL_LOAD_ADDR>;
+            entry = <$KERNEL_LOAD_ADDR>;
+        };
+        fdt {
+            data = /incbin/("merged.dtb");
+            type = "flat_dt";
+            arch = "arm";
+            compression = "none";
+            load = <$FDT_LOAD_ADDR>;
+        };
+    };
+    configurations {
+        default = "conf";
+        conf {
+            kernel = "kernel";
+            fdt = "fdt";
+        };
+    };
+};
+EOF
+
+mkimage -f image.its -A arm zboot_merged.img -r || \
+    { echo "merge-dt-overlays-boot: mkimage failed to repack FIT" >&2; exit 1; }
+
+mkdir -p "$OUTPUT_DIR"
+# Atomic replace: temp then rename, then stamp (crash cannot leave torn FIT + matching stamp)
+install -m 0644 zboot_merged.img "$OUTPUT_DIR/${OUT_BASENAME}.tmp"
+mv -f "$OUTPUT_DIR/${OUT_BASENAME}.tmp" "$OUTPUT_DIR/$OUT_BASENAME"
+fit_kernel_stamp "$FIT_KERNEL" > "$STAMP_FILE"
+echo "merge-dt-overlays-boot: wrote $OUT_BASENAME for RAUC slot $SLOT (${#OVERLAY_FILES[@]} overlays)"

--- a/meta-calculinux-distro/recipes-core/systemd/merge-dt-overlays-boot.bb
+++ b/meta-calculinux-distro/recipes-core/systemd/merge-dt-overlays-boot.bb
@@ -24,6 +24,7 @@ SYSTEMD_SERVICE:${PN} = "merge-dt-overlays-boot.service merge-dt-overlays-boot.p
 SYSTEMD_AUTO_ENABLE = "enable"
 
 RDEPENDS:${PN} += "bash u-boot-tools dtc u-boot-fw-config"
+CONFFILES:${PN} += "${sysconfdir}/device-tree-overlays.conf"
 
 do_install() {
     install -D -m 0644 ${S}/fit-stamp.sh ${D}${libdir}/systemd/fit-stamp.sh

--- a/meta-calculinux-distro/recipes-core/systemd/merge-dt-overlays-boot.bb
+++ b/meta-calculinux-distro/recipes-core/systemd/merge-dt-overlays-boot.bb
@@ -1,0 +1,46 @@
+SUMMARY = "Merge device tree overlays into zboot FIT for next boot"
+DESCRIPTION = "Builds zboot_merged_<slot>.img for the current RAUC slot from \
+/boot/fit_* and overlays in /etc/device-tree-overlays.conf. U-Boot loads that \
+slot's FIT, then falls back to /boot/zboot_merged.img (never the other slot)."
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = " \
+    file://fit-stamp.sh \
+    file://merge-dt-overlays-boot.sh \
+    file://merge-dt-overlays-boot.service \
+    file://merge-dt-overlays-boot.path \
+    file://clear-fit-rewritten.service \
+    file://device-tree-overlays.conf \
+"
+
+S = "${UNPACKDIR}"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "merge-dt-overlays-boot.service merge-dt-overlays-boot.path clear-fit-rewritten.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+RDEPENDS:${PN} += "bash u-boot-tools dtc u-boot-fw-config"
+
+do_install() {
+    install -D -m 0644 ${S}/fit-stamp.sh ${D}${libdir}/systemd/fit-stamp.sh
+    install -D -m 0755 ${S}/merge-dt-overlays-boot.sh ${D}${libdir}/systemd/merge-dt-overlays-boot.sh
+    install -D -m 0644 ${S}/merge-dt-overlays-boot.service ${D}${systemd_system_unitdir}/merge-dt-overlays-boot.service
+    install -D -m 0644 ${S}/merge-dt-overlays-boot.path ${D}${systemd_system_unitdir}/merge-dt-overlays-boot.path
+    install -D -m 0644 ${S}/clear-fit-rewritten.service ${D}${systemd_system_unitdir}/clear-fit-rewritten.service
+    install -D -m 0644 ${S}/device-tree-overlays.conf ${D}${sysconfdir}/device-tree-overlays.conf
+}
+
+FILES:${PN} = " \
+    ${libdir}/systemd/fit-stamp.sh \
+    ${libdir}/systemd/merge-dt-overlays-boot.sh \
+    ${systemd_system_unitdir}/merge-dt-overlays-boot.service \
+    ${systemd_system_unitdir}/merge-dt-overlays-boot.path \
+    ${systemd_system_unitdir}/clear-fit-rewritten.service \
+    ${sysconfdir}/device-tree-overlays.conf \
+"
+
+COMPATIBLE_MACHINE = "luckfox-lyra"

--- a/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/files/boot.scr.sh.in
+++ b/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/files/boot.scr.sh.in
@@ -4,9 +4,7 @@ if test "x${{BOOT_ORDER}}" = "x"; then
     saveenv;
 fi;
 test -n "${{BOOT_A_LEFT}}" || setenv BOOT_A_LEFT 1;
-test "${{BOOT_A_LEFT}}" = 3 && setenv BOOT_A_LEFT 1;
 test -n "${{BOOT_B_LEFT}}" || setenv BOOT_B_LEFT 1;
-test "${{BOOT_B_LEFT}}" = 3 && setenv BOOT_B_LEFT 1;
 
 setenv rauc_slot;
 
@@ -55,15 +53,52 @@ saveenv;
 saveenv;
 
 setenv fit_image "zboot.img"
-
 test -n "${{baudrate}}" || setenv baudrate 1500000;
 test -n "${{consoleblank}}" || setenv consoleblank 300;
 
 setenv bootargs "console=${{console}} earlycon=uart8250,mmio32,0xff0a0000,${{baudrate}} console=ttyFIQ0,${{baudrate}} consoleblank=${{consoleblank}} rockchip.fiq_debugger_baudrate=${{baudrate}} ro rootwait root=PARTLABEL=ROOT_${{rauc_slot}} rauc.slot=${{rauc_slot}} fsck.mode=skip noinitrd init=/sbin/preinit regulator.debug=1";
 echo Setting bootargs to ${{bootargs}};
 
-echo Loading FIT image <${{fit_image}}> from ${{devtype}} ${{devnum}}:${{mmcpart}};
-load ${{devtype}} ${{devnum}}:${{mmcpart}} ${{ramdisk_addr_r}} /boot/${{fit_image}};
+setenv filesize 0;
+setenv fit_loaded 0;
+setenv overlay_part;
+setenv overlay_part_hex;
+part number ${{devtype}} ${{devnum}} OVERLAY_DATA overlay_part_hex;
+if test -n "${{overlay_part_hex}}"; then
+    setexpr overlay_part fmt %d ${{overlay_part_hex}};
+fi;
+if test "${{FIT_LAST_TRIED}}" = "data"; then
+    setenv fit_try "boot";
+else
+    setenv fit_try "data";
+fi;
 
+# This RAUC slot's merged FIT only — never the other slot (different kernel).
+# Skip data FIT if OVERLAY_DATA partition lookup failed.
+if test "${{fit_try}}" = "data"; then
+    if test -n "${{overlay_part}}"; then
+        if test "${{rauc_slot}}" = "A"; then
+            load ${{devtype}} ${{devnum}}:${{overlay_part}} ${{ramdisk_addr_r}} fit/zboot_merged_a.img;
+        else
+            load ${{devtype}} ${{devnum}}:${{overlay_part}} ${{ramdisk_addr_r}} fit/zboot_merged_b.img;
+        fi;
+        if test ${{filesize}} -gt 0; then setenv fit_loaded 1; setenv FIT_LAST_TRIED data; fi;
+    fi;
+fi;
+
+# Same-slot /boot fallback (correct kernel; default or no user overlays)
+if test ${{fit_loaded}} -eq 0; then
+    load ${{devtype}} ${{devnum}}:${{mmcpart}} ${{ramdisk_addr_r}} /boot/zboot_merged.img;
+    if test ${{filesize}} -gt 0; then setenv fit_loaded 1; setenv FIT_LAST_TRIED boot; fi;
+fi;
+
+if test ${{fit_loaded}} -eq 1; then
+    echo Booting FIT ${{FIT_LAST_TRIED}};
+    saveenv;
+    bootm ${{ramdisk_addr_r}};
+fi;
+
+echo Loading unmerged zboot from ROOT;
+load ${{devtype}} ${{devnum}}:${{mmcpart}} ${{ramdisk_addr_r}} /boot/${{fit_image}};
 echo Booting from address <${{ramdisk_addr_r}}>;
 bootm ${{ramdisk_addr_r}}

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -258,6 +258,9 @@ do_install:append() {
 # a previous build or sstate) so the deploy class does not fail with "files
 # already exist (not matched to any task)" when it copies.
 do_deploy:append() {
+    rm -f "${DEPLOY_DIR_IMAGE}/fit_fdt.dtb" \
+          "${DEPLOY_DIR_IMAGE}/fit_kernel" \
+          "${DEPLOY_DIR_IMAGE}/fit_compression.txt"
     install -m 0644 "${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE}" "${DEPLOYDIR}/fit_fdt.dtb"
     # Same kernel blob that is packed into zboot.img (arm=zImage, arm64=Image.lz4)
     if [ "${ARCH}" = "arm64" ]; then

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -58,9 +58,9 @@ KERNEL_IMAGETYPES = "zboot.img"
 
 # --- Device Tree Overlay Symbol Support ---
 #
-# Runtime ConfigFS overlays need a __symbols__ node in the base DTB so the
-# kernel can resolve phandle label references (e.g. &i2c2, &pinctrl) at
-# overlay-apply time.
+# ConfigFS overlay apply and userspace fdtoverlay (merge-dt-overlays-boot /
+# default-merged-fit) need a __symbols__ node in the base DTB so phandle
+# label references (e.g. &i2c2, &pinctrl) resolve.
 #
 # However, compiling with DTC's -@ flag adds __symbols__ for EVERY labelled
 # node. On the RK3506, the RMIO pinctrl DTSI alone defines ~3,100 labels
@@ -254,7 +254,9 @@ do_install:append() {
 # Deploy the kernel blob and FDT that go into zboot.img so default-merged-fit
 # can build the merged FIT directly without extracting from zboot.img.
 # Must use DEPLOYDIR only: the deploy class copies DEPLOYDIR -> DEPLOY_DIR_IMAGE
-# and tracks the manifest.
+# and tracks the manifest. Remove any stale fit_* in DEPLOY_DIR_IMAGE (e.g. from
+# a previous build or sstate) so the deploy class does not fail with "files
+# already exist (not matched to any task)" when it copies.
 do_deploy:append() {
     install -m 0644 "${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE}" "${DEPLOYDIR}/fit_fdt.dtb"
     # Same kernel blob that is packed into zboot.img (arm=zImage, arm64=Image.lz4)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Split FIT-at-boot out of #147 onto current `main`. No M0 audio, rproc, or `remoteproc.cfg`.
- Keep ConfigFS (`0001-of-configfs`, `dto.cfg`). Overlays install to `/boot/devicetree` **and** `/lib/firmware/overlays`.
- U-Boot prefers `/data/fit/zboot_merged_<slot>.img`, then `/boot/zboot_merged.img`, then unmerged `zboot.img`.
- RAUC post-install and preinit drop a stale per-slot FIT.

**Merge this first.** Then test with the known-working RTC overlay (`ds3231-rtc` in `/etc/device-tree-overlays.conf`). M0 audio + unused `snd-pins` in the base dtsi is #165 (rebased #145); merge that after FIT works.

#147 still carries M0 packaging and drops ConfigFS; this PR is the FIT slice.

## Test plan
- [ ] `bash meta-calculinux-distro/recipes-core/systemd/files/merge-dt-overlays-boot-check.sh` passes (already run in this change).
- [ ] Fresh boot uses `/boot/zboot_merged.img`, then writes `/data/fit/zboot_merged_<slot>.img`.
- [ ] ConfigFS DS3231 still applies (`cat …/ds3231-rtc.dtbo` into ConfigFS).
- [ ] Add `ds3231-rtc` to `/etc/device-tree-overlays.conf`, reboot; RTC is in the merged DTB (`/dev/rtc1` after boot, no ConfigFS).
- [ ] RAUC update boots the new kernel (not the other slot’s FIT).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e73f4796-163e-48ee-bd71-27c2c7bbf079?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e73f4796-163e-48ee-bd71-27c2c7bbf079&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

