### PR TITLE
Unstick rtl8xxxu 8188EU TX from MCS 0 after the BA session is up.

### DIFF
--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-ampdu-density-4us.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-ampdu-density-4us.patch
@@ -1,0 +1,29 @@
+rtl8xxxu: advertise 4us RX A-MPDU density instead of 16us
+
+IEEE80211_HT_MPDU_DENSITY_16 tells the AP to leave 16us between MPDUs
+in aggregates sent to us. That is the most conservative spacing and
+caps 8188EU download A-MPDU efficiency, especially on TCP ACKs.
+
+4us matches typical USB 802.11n clients. TX density still comes from
+the peer HT cap.
+
+Upstream-Status: Pending
+
+Signed-off-by: Ben Klopfenstein <benklop@gmail.com>
+
+---
+ rtl8xxxu_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rtl8xxxu_core.c b/rtl8xxxu_core.c
+--- a/rtl8xxxu_core.c
++++ b/rtl8xxxu_core.c
+@@ -8091,7 +8091,7 @@ int rtl8xxxu_probe(struct usb_interface *interface,
+ 	sband = &rtl8xxxu_supported_band;
+ 	sband->ht_cap.ht_supported = true;
+ 	sband->ht_cap.ampdu_factor = IEEE80211_HT_MAX_AMPDU_64K;
+-	sband->ht_cap.ampdu_density = IEEE80211_HT_MPDU_DENSITY_16;
++	sband->ht_cap.ampdu_density = IEEE80211_HT_MPDU_DENSITY_4;
+ 	sband->ht_cap.cap = IEEE80211_HT_CAP_SGI_20 | IEEE80211_HT_CAP_SGI_40;
+ 	memset(&sband->ht_cap.mcs, 0, sizeof(sband->ht_cap.mcs));
+ 	sband->ht_cap.mcs.rx_mask[0] = 0xff;

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-ht40-default-on.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-ht40-default-on.patch
@@ -1,0 +1,27 @@
+rtl8xxxu: enable HT40 on 2.4 GHz by default
+
+Mainline dropped the ht40_2g opt-in after the channel-setup bugs that
+made 40 MHz miserable were fixed. 8188EU is stuck on HT20 MCS 0-1
+(~6.5 Mbps TX). Advertise 40 MHz so the AP can give us HT40; keep the
+module parameter so ht40_2g=0 still disables it.
+
+Upstream-Status: Backport [https://git.kernel.org/linus/dbf9b7bb0edfa192d43ebb41dd0e1041f8a9c5b0]
+
+Signed-off-by: Ben Klopfenstein <benklop@gmail.com>
+
+---
+ rtl8xxxu_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rtl8xxxu_core.c b/rtl8xxxu_core.c
+--- a/rtl8xxxu_core.c
++++ b/rtl8xxxu_core.c
+@@ -20,7 +20,7 @@
+ #define DRIVER_NAME "rtl8xxxu"
+ 
+ int rtl8xxxu_debug;
+-static bool rtl8xxxu_ht40_2g;
++static bool rtl8xxxu_ht40_2g = true;
+ static bool rtl8xxxu_dma_aggregation;
+ static int rtl8xxxu_dma_agg_timeout = -1;
+ static int rtl8xxxu_dma_agg_pages = -1;

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-sta-data-size.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-sta-data-size.patch
@@ -1,0 +1,27 @@
+rtl8xxxu: set hw->sta_data_size for per-station RA state
+
+mac80211 only allocates sta->drv_priv when sta_data_size is set.
+rtl8xxxu_sta_add / rtl8xxxu_refresh_rate_mask write rssi_level and
+avg_rssi there. Without this, those writes are OOB and 8188EU host
+rate control can stay pinned at MCS 0.
+
+Fixes: eef55f1545c9 ("wifi: rtl8xxxu: support multiple interfaces")
+Upstream-Status: Backport [https://git.kernel.org/linus/86c946bcc00f6390ef65e9614ae60a9377e454f8]
+
+Signed-off-by: Ben Klopfenstein <benklop@gmail.com>
+
+---
+ rtl8xxxu_core.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/rtl8xxxu_core.c b/rtl8xxxu_core.c
+--- a/rtl8xxxu_core.c
++++ b/rtl8xxxu_core.c
+@@ -8074,6 +8074,7 @@ int rtl8xxxu_probe(struct usb_interface *interface,
+ 		goto err_set_intfdata;
+ 
+ 	hw->vif_data_size = sizeof(struct rtl8xxxu_vif);
++	hw->sta_data_size = sizeof(struct rtl8xxxu_sta_info);
+ 
+ 	hw->wiphy->max_scan_ssids = 1;
+ 	hw->wiphy->max_scan_ie_len = IEEE80211_MAX_DATA_LEN;

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-v3-rts-only-when-requested.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-v3-rts-only-when-requested.patch
@@ -1,0 +1,29 @@
+rtl8xxxu: do not force RTS/CTS on 8188EU A-MPDU
+
+fill_txdesc_v3 treats ampdu_enable as "needs RTS". After the BA session
+is up that puts RTS/CTS on every aggregated frame, including TCP ACKs,
+so download ACK clocking stays poor even though RA can leave MCS 0.
+
+Only enable RTS/CTS when mac80211 or the RTS threshold asks for it.
+CTS-to-self for ERP protection is unchanged.
+
+Upstream-Status: Pending
+
+Signed-off-by: Ben Klopfenstein <benklop@gmail.com>
+
+---
+ rtl8xxxu_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rtl8xxxu_core.c b/rtl8xxxu_core.c
+--- a/rtl8xxxu_core.c
++++ b/rtl8xxxu_core.c
+@@ -5536,7 +5536,7 @@ rtl8xxxu_fill_txdesc_v3(struct ieee80211_hw *hw, struct ieee80211_hdr *hdr,
+ 	 * rts_rate is zero if RTS/CTS or CTS to SELF are not enabled
+ 	 */
+ 	tx_desc->txdw4 |= cpu_to_le32(rts_rate << TXDESC32_RTS_RATE_SHIFT);
+-	if (ampdu_enable || tx_info->control.use_rts) {
++	if (tx_info->control.use_rts) {
+ 		tx_desc->txdw4 |= cpu_to_le32(TXDESC32_RTS_CTS_ENABLE);
+ 		tx_desc->txdw4 |= cpu_to_le32(TXDESC32_HW_RTS_ENABLE);
+ 	} else if (tx_info->control.use_cts_prot) {

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/rtl8xxxu_git.bb
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/rtl8xxxu_git.bb
@@ -13,6 +13,10 @@ SRC_URI = "\
     file://rtl8188eu-needs-full-init.patch \
     file://rtl8xxxu-retry-firmware-download.patch \
     file://rtl8xxxu-ampdu-rts-only-when-operational.patch \
+    file://rtl8xxxu-v3-rts-only-when-requested.patch \
+    file://rtl8xxxu-ampdu-density-4us.patch \
+    file://rtl8xxxu-sta-data-size.patch \
+    file://rtl8xxxu-ht40-default-on.patch \
     "
 SRCREV = "7cb5b73796b19b460af835144e604595083ca60d"
 


### PR DESCRIPTION
Stop forcing RTS on every A-MPDU, advertise 4us RX density, allocate sta->drv_priv so host RA is not OOB, and enable HT40 by default.