### PR TITLE
Stop 8188E vendor RA from walking to MCS 0 on TCP download

### DIFF
--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-8188e-ra-first-try-holds.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-8188e-ra-first-try-holds.patch
@@ -1,0 +1,37 @@
+rtl8xxxu: do not rate-down 8188EU when first-try TX succeeds
+
+The MAC TX report cannot tell a half-duplex collision from a bad MCS.
+DROP and RTY[1..] increment when a TCP ACK is sent into the AP's RX
+burst; RTY[0] still shows most frames succeeding first try.
+
+nsc_down treats those retries as "rate too high" and walks MCS 7→3→2
+under a download. If first-try successes are at least half the window,
+keep the current MCS. A genuinely bad rate has retry[0] in the minority.
+
+Upstream-Status: Pending
+
+Signed-off-by: Ben Klopfenstein <benklop@gmail.com>
+
+---
+ rtl8xxxu_8188e.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/rtl8xxxu_8188e.c b/rtl8xxxu_8188e.c
+--- a/rtl8xxxu_8188e.c
++++ b/rtl8xxxu_8188e.c
+@@ -1536,10 +1536,14 @@ static void rtl8188e_rate_decision(struct rtl8xxxu_ra_info *ra)
+ 	else
+ 		ra->nsc_up = 0;
+ 
+-	if (ra->nsc_down < n_threshold_low[rate_id] ||
++	/* Hardware cannot tag collision vs bad MCS. If most frames
++	 * succeed first try, leftover retries/drops are RX/TX overlap.
++	 */
++	if (ra->retry[0] * 2 < ra->total &&
++	    (ra->nsc_down < n_threshold_low[rate_id] ||
+ 	    (ra->drop > dropping_necessary[rate_id] &&
+-	     ra->drop * 4 > ra->total)) {
++	     ra->drop * 4 > ra->total))) {
+ 		/* Sparse drops are 1T1R RX/TX collisions, not a bad MCS. */
+ 		rtl8188e_rate_down(ra);
+ 

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-8188e-ra-ignore-collision-drops.patch
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/files/rtl8xxxu-8188e-ra-ignore-collision-drops.patch
@@ -1,0 +1,34 @@
+rtl8xxxu: do not let 8188EU RA collapse on half-duplex ACK drops
+
+A TCP download is RX data plus TX ACKs on the same 1T1R radio. Hardware
+TX reports count those ACK collisions as drops. dropping_necessary is 3
+at MCS 2 and 1 at MCS 0, so a handful of collisions per 200 ms report
+walks decision_rate to MCS 0 and parks there. Downloads then start
+around 2 MB/s and fall toward 1 MB/s as ACK airtime grows.
+
+Only treat drops as a rate-down if they are a large fraction of the
+window (>25%). Retry-weighted nsc_down is unchanged, so a genuinely
+too-high MCS still falls.
+
+Upstream-Status: Pending
+
+Signed-off-by: Ben Klopfenstein <benklop@gmail.com>
+
+---
+ rtl8xxxu_8188e.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/rtl8xxxu_8188e.c b/rtl8xxxu_8188e.c
+--- a/rtl8xxxu_8188e.c
++++ b/rtl8xxxu_8188e.c
+@@ -1537,7 +1537,9 @@ static void rtl8188e_rate_decision(struct rtl8xxxu_ra_info *ra)
+ 		ra->nsc_up = 0;
+ 
+ 	if (ra->nsc_down < n_threshold_low[rate_id] ||
+-	    ra->drop > dropping_necessary[rate_id]) {
++	    (ra->drop > dropping_necessary[rate_id] &&
++	     ra->drop * 4 > ra->total)) {
++		/* Sparse drops are 1T1R RX/TX collisions, not a bad MCS. */
+ 		rtl8188e_rate_down(ra);
+ 
+ 		rtl8xxxu_update_ra_report(&priv->ra_report, ra->decision_rate,

--- a/meta-calculinux-distro/recipes-connectivity/wifi-drivers/rtl8xxxu_git.bb
+++ b/meta-calculinux-distro/recipes-connectivity/wifi-drivers/rtl8xxxu_git.bb
@@ -17,6 +17,8 @@ SRC_URI = "\
     file://rtl8xxxu-ampdu-density-4us.patch \
     file://rtl8xxxu-sta-data-size.patch \
     file://rtl8xxxu-ht40-default-on.patch \
+    file://rtl8xxxu-8188e-ra-ignore-collision-drops.patch \
+    file://rtl8xxxu-8188e-ra-first-try-holds.patch \
     "
 SRCREV = "7cb5b73796b19b460af835144e604595083ca60d"
 


### PR DESCRIPTION
## Summary
- Forced RTS / A-MPDU density / sta_data_size / HT40 (already on main via #166)
- 8188E RA: ignore sparse collision-shaped TX-report drops; hold rate when first-try successes are the majority (bidirectional TCP download was walking MCS to 0)

## Test plan
- LAN 32MB wget over wlan (USB SSH to 10.42.0.248), no `iw` during transfer
- Confirm TX stays MCS 7 SGI / ~1.9–2.1 MB/s instead of fading to MCS 0
- Reboot still uses image module until image rebuilt

Measured on live `insmod` of these patches: wget1 2.09 MB/s TX MCS 7 SGI; wget2 1.89 MB/s TX MCS 7 SGI / RX MCS 7. Baseline 64414db without RA patches: 1.59 MB/s fade, TX parked MCS 0.
