### PR TITLE
usb-gadget: drop stale USB route when the host unplugs

### DIFF
--- a/meta-calculinux-distro/recipes-bsp/drivers/files/vbus-always-on.dtsi.patch
+++ b/meta-calculinux-distro/recipes-bsp/drivers/files/vbus-always-on.dtsi.patch
@@ -1,0 +1,32 @@
+From: Calculinux <noreply@calculinux>
+Subject: dt: mark Luckfox Lyra OTG VBUS as always on
+
+OTG VBUS is diode-ORed to VCC5V0_SYS. Carry picocalc-drivers#29 on the
+currently pinned tree so we do not also pull the M0 rproc build.
+
+---
+ linux-rk3506-luckfox-lyra.dtsi | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/linux-rk3506-luckfox-lyra.dtsi b/linux-rk3506-luckfox-lyra.dtsi
+index a949261..8e21301 100644
+--- a/linux-rk3506-luckfox-lyra.dtsi
++++ b/linux-rk3506-luckfox-lyra.dtsi
+@@ -182,6 +182,8 @@
+ /**********usb**********/
+ &usb20_otg0 {
+ 	dr_mode = "otg";
++	/* OTG VBUS is diode-ORed to VCC5V0_SYS / VSYS; it never drops. */
++	snps,vbus-always-on;
+ 	/* vbus-supply = <&vcc5v0_otg0>;
+ 	rockchip,gpio-vbus-det; */
+ 	status = "okay";
+@@ -198,6 +200,7 @@
+ };
+ 
+ &u2phy_otg0 {
++	rockchip,vbus-always-on;
+ 	status = "okay";
+ };
+ 
+--

--- a/meta-calculinux-distro/recipes-bsp/drivers/picocalc-devicetree_1.0.bb
+++ b/meta-calculinux-distro/recipes-bsp/drivers/picocalc-devicetree_1.0.bb
@@ -7,6 +7,9 @@ PR = "r0"
 
 require picocalc-drivers-source.inc
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://vbus-always-on.dtsi.patch"
+
 COMPATIBLE_MACHINE = "luckfox-lyra"
 
 do_configure[noexec] = "1"
@@ -14,11 +17,11 @@ do_compile[noexec] = "1"
 
 do_install() {
     install -d ${D}${datadir}/picocalc
-    install -m 0644 ${S}/luckfox-lyra/picocalc-luckfox-lyra.dtsi ${D}${datadir}/picocalc/
-    install -m 0644 ${S}/luckfox-lyra/linux-rk3506-luckfox-lyra.dtsi ${D}${datadir}/picocalc/rk3506-luckfox-lyra.dtsi
-    install -m 0644 ${S}/luckfox-lyra/linux-rk3506g-luckfox-lyra.dts ${D}${datadir}/picocalc/rk3506g-luckfox-lyra.dts
-    install -m 0644 ${S}/luckfox-lyra/uboot-rk3506-luckfox.dtsi ${D}${datadir}/picocalc/rk3506-luckfox.dtsi
-    install -m 0644 ${S}/luckfox-lyra/uboot-rk3506-luckfox.dts ${D}${datadir}/picocalc/rk3506-luckfox.dts
+    install -m 0644 ${S}/picocalc-luckfox-lyra.dtsi ${D}${datadir}/picocalc/
+    install -m 0644 ${S}/linux-rk3506-luckfox-lyra.dtsi ${D}${datadir}/picocalc/rk3506-luckfox-lyra.dtsi
+    install -m 0644 ${S}/linux-rk3506g-luckfox-lyra.dts ${D}${datadir}/picocalc/rk3506g-luckfox-lyra.dts
+    install -m 0644 ${S}/uboot-rk3506-luckfox.dtsi ${D}${datadir}/picocalc/rk3506-luckfox.dtsi
+    install -m 0644 ${S}/uboot-rk3506-luckfox.dts ${D}${datadir}/picocalc/rk3506-luckfox.dts
 
     # Overlay symbol whitelist – consumed by the kernel recipe to inject only
     # the needed __symbols__ entries into the base DTB.

--- a/meta-calculinux-distro/recipes-bsp/drivers/picocalc-devicetree_1.0.bb
+++ b/meta-calculinux-distro/recipes-bsp/drivers/picocalc-devicetree_1.0.bb
@@ -14,11 +14,11 @@ do_compile[noexec] = "1"
 
 do_install() {
     install -d ${D}${datadir}/picocalc
-    install -m 0644 ${S}/picocalc-luckfox-lyra.dtsi ${D}${datadir}/picocalc/
-    install -m 0644 ${S}/linux-rk3506-luckfox-lyra.dtsi ${D}${datadir}/picocalc/rk3506-luckfox-lyra.dtsi
-    install -m 0644 ${S}/linux-rk3506g-luckfox-lyra.dts ${D}${datadir}/picocalc/rk3506g-luckfox-lyra.dts
-    install -m 0644 ${S}/uboot-rk3506-luckfox.dtsi ${D}${datadir}/picocalc/rk3506-luckfox.dtsi
-    install -m 0644 ${S}/uboot-rk3506-luckfox.dts ${D}${datadir}/picocalc/rk3506-luckfox.dts
+    install -m 0644 ${S}/luckfox-lyra/picocalc-luckfox-lyra.dtsi ${D}${datadir}/picocalc/
+    install -m 0644 ${S}/luckfox-lyra/linux-rk3506-luckfox-lyra.dtsi ${D}${datadir}/picocalc/rk3506-luckfox-lyra.dtsi
+    install -m 0644 ${S}/luckfox-lyra/linux-rk3506g-luckfox-lyra.dts ${D}${datadir}/picocalc/rk3506g-luckfox-lyra.dts
+    install -m 0644 ${S}/luckfox-lyra/uboot-rk3506-luckfox.dtsi ${D}${datadir}/picocalc/rk3506-luckfox.dtsi
+    install -m 0644 ${S}/luckfox-lyra/uboot-rk3506-luckfox.dts ${D}${datadir}/picocalc/rk3506-luckfox.dts
 
     # Overlay symbol whitelist – consumed by the kernel recipe to inject only
     # the needed __symbols__ entries into the base DTB.

--- a/meta-calculinux-distro/recipes-bsp/drivers/picocalc-drivers-source.inc
+++ b/meta-calculinux-distro/recipes-bsp/drivers/picocalc-drivers-source.inc
@@ -1,5 +1,5 @@
 PV = "1.0+git${SRCPV}"
 SRC_URI = "git://github.com/Calculinux/picocalc-drivers.git;protocol=https;nobranch=1"
-# overlay-symbols.txt for kernel __symbols__ injection (Calculinux/picocalc-drivers#26)
-SRCREV = "74dc424722c20db62b9dbbf95a1889b339a85226"
+# VBUS-always-on DT flags for the gadget SOF watchdog (Calculinux/picocalc-drivers#29)
+SRCREV = "88daa9c38a111dd8c1424d6c396e74b27f26a8fa"
 S = "${WORKDIR}/git"

--- a/meta-calculinux-distro/recipes-bsp/drivers/picocalc-drivers-source.inc
+++ b/meta-calculinux-distro/recipes-bsp/drivers/picocalc-drivers-source.inc
@@ -1,5 +1,5 @@
 PV = "1.0+git${SRCPV}"
 SRC_URI = "git://github.com/Calculinux/picocalc-drivers.git;protocol=https;nobranch=1"
-# VBUS-always-on DT flags for the gadget SOF watchdog (Calculinux/picocalc-drivers#29)
-SRCREV = "88daa9c38a111dd8c1424d6c396e74b27f26a8fa"
+# overlay-symbols.txt for kernel __symbols__ injection (Calculinux/picocalc-drivers#26)
+SRCREV = "74dc424722c20db62b9dbbf95a1889b339a85226"
 S = "${WORKDIR}/git"

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/50-usb-gadget-link.rules
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/50-usb-gadget-link.rules
@@ -1,3 +1,5 @@
-# VBUS cannot drop on this board. dwc2 SOF watchdog emits this on unplug.
-SUBSYSTEM=="udc", ACTION=="change", ATTR{state}=="not attached", \
+# VBUS cannot drop on this board. CONFIG_USB_CONFIGFS_UEVENT android0
+# emits USB_STATE=DISCONNECTED after the dwc2 SOF watchdog disconnects.
+# UDC state stays "configured" on unplug, so do not match on udc.
+SUBSYSTEM=="android_usb", ACTION=="change", ENV{USB_STATE}=="DISCONNECTED", \
   TAG+="systemd", ENV{SYSTEMD_WANTS}+="usb-gadget-link.service"

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/50-usb-gadget-link.rules
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/50-usb-gadget-link.rules
@@ -1,0 +1,3 @@
+# VBUS cannot drop on this board. dwc2 SOF watchdog emits this on unplug.
+SUBSYSTEM=="android_usb", ACTION=="change", ENV{USB_STATE}=="DISCONNECTED", \
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="usb-gadget-link.service"

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/50-usb-gadget-link.rules
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/50-usb-gadget-link.rules
@@ -1,3 +1,3 @@
 # VBUS cannot drop on this board. dwc2 SOF watchdog emits this on unplug.
-SUBSYSTEM=="android_usb", ACTION=="change", ENV{USB_STATE}=="DISCONNECTED", \
+SUBSYSTEM=="udc", ACTION=="change", ATTR{state}=="not attached", \
   TAG+="systemd", ENV{SYSTEMD_WANTS}+="usb-gadget-link.service"

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link
@@ -1,0 +1,9 @@
+#!/bin/busybox ash
+# android_usb DISCONNECTED: bounce usb* so networkd drops a stale DHCP lease.
+for path in /sys/class/net/usb*; do
+    [ -e "$path" ] || continue
+    iface=${path##*/}
+    echo "usb-gadget-link: $iface host gone, bouncing"
+    networkctl down "$iface" 2>/dev/null || ip link set "$iface" down || true
+    networkctl up "$iface" 2>/dev/null || ip link set "$iface" up || true
+done

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link
@@ -1,4 +1,4 @@
-#!/bin/busybox ash
+#!/bin/sh
 # android_usb DISCONNECTED: bounce usb* so networkd drops a stale DHCP lease.
 for path in /sys/class/net/usb*; do
     [ -e "$path" ] || continue

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link.service
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Bounce USB gadget after host disconnect
+After=usb-gadget-network.service systemd-networkd.service
+PartOf=usb-gadget-network.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/usb-gadget-link

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link.service
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb-gadget-link.service
@@ -2,7 +2,6 @@
 Description=Bounce USB gadget after host disconnect
 After=usb-gadget-network.service systemd-networkd.service
 PartOf=usb-gadget-network.service
-DefaultDependencies=no
 
 [Service]
 Type=oneshot

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb0.network
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/files/usb0.network
@@ -8,5 +8,15 @@ LinkLocalAddressing=yes
 # Optional: Enable DHCP client if host provides DHCP
 DHCP=yes
 
+# Prefer this default route over iwd WLAN (RoutePriorityOffset default is 300)
+[DHCPv4]
+RouteMetric=100
+
+[DHCPv6]
+RouteMetric=100
+
+[IPv6AcceptRA]
+RouteMetric=100
+
 [Link]
 RequiredForOnline=no

--- a/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/usb-gadget-network.bb
+++ b/meta-calculinux-distro/recipes-connectivity/usb-gadget-network/usb-gadget-network.bb
@@ -5,8 +5,11 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = " \
     file://usb-gadget-network.sh \
+    file://usb-gadget-link \
     file://usb-modeswitch \
     file://usb-gadget-network.service \
+    file://usb-gadget-link.service \
+    file://50-usb-gadget-link.rules \
     file://usb0.network \
     file://usb-gadget-network.default \
     file://serial-getty@ttyGS0.service \
@@ -36,13 +39,18 @@ do_install() {
     # Install the configuration script
     install -d ${D}${bindir}
     install -m 0755 ${UNPACKDIR}/usb-gadget-network.sh ${D}${bindir}/
+    install -m 0755 ${UNPACKDIR}/usb-gadget-link ${D}${bindir}/
     install -m 0755 ${UNPACKDIR}/usb-gadget-serial-console.sh ${D}${bindir}/
     install -m 0755 ${UNPACKDIR}/usb-modeswitch ${D}${bindir}/
 
     # Install systemd service
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/usb-gadget-network.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${UNPACKDIR}/usb-gadget-link.service ${D}${systemd_system_unitdir}/
     install -m 0644 ${UNPACKDIR}/serial-getty@ttyGS0.service ${D}${systemd_system_unitdir}/
+
+    install -d ${D}${nonarch_base_libdir}/udev/rules.d
+    install -m 0644 ${UNPACKDIR}/50-usb-gadget-link.rules ${D}${nonarch_base_libdir}/udev/rules.d/
     install -m 0644 ${UNPACKDIR}/usb-gadget-serial-console.service ${D}${systemd_system_unitdir}/
 
     # Install systemd network configuration
@@ -60,6 +68,8 @@ do_install() {
 
 FILES:${PN} += " \
     ${systemd_system_unitdir}/usb-gadget-network.service \
+    ${systemd_system_unitdir}/usb-gadget-link.service \
+    ${nonarch_base_libdir}/udev/rules.d/50-usb-gadget-link.rules \
     ${systemd_system_unitdir}/serial-getty@ttyGS0.service \
     ${systemd_system_unitdir}/usb-gadget-serial-console.service \
     ${systemd_unitdir}/network/usb0.network \

--- a/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-kernel/linux/linux-rockchip_6.1.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 LICENSE = "GPL-2.0-only"
 
-SRCREV = "815d6a4af7589b0da6cc765658913d05fe550965"
+SRCREV = "31300da39d37ec56b3df205519aaa9eb943fccfb"
 
 # Kernel config fragments: all .cfg files in files/ are auto-included.
 # Add new fragments by copying to files/ (e.g. via scripts/copy-kernel-fragment.sh).


### PR DESCRIPTION
## Summary
- Bump `linux-rockchip` to [Calculinux/luckfox-linux-6.1-rk3506#17](https://github.com/Calculinux/luckfox-linux-6.1-rk3506/pull/17) (`31300da`) so dwc2 can disconnect on a stuck SOF when VBUS cannot drop.
- Bump `picocalc-drivers` to [Calculinux/picocalc-drivers#29](https://github.com/Calculinux/picocalc-drivers/pull/29) (`88daa9c`) and install DT from `luckfox-lyra/` so the image actually sets `snps,vbus-always-on` / `rockchip,vbus-always-on`.
- On `android_usb` `USB_STATE=DISCONNECTED`, bounce `usb*` so networkd drops a stale DHCP default route. Prefer USB (metric 100) over iwd WLAN.

## Test plan
- [ ] Image builds (`picocalc-devicetree` finds the `luckfox-lyra/` DT files).
- [ ] Plug USB gadget ethernet: `usb0` gets a lease and a metric-100 default route.
- [ ] Unplug: dmesg shows the SOF watchdog disconnect; `usb-gadget-link` runs; the USB default route is gone and WLAN is used.
- [ ] Replug with no extra command: gadget enumerates, DHCP/route return.
