### PR TITLE
Cancel superseded CI builds when a branch or PR is pushed again.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ permissions:
   contents: write      # Needed for creating releases
   pull-requests: write # Needed for commenting on PRs
 
+# Drop superseded runs when a branch/PR is pushed again (Yocto builds are expensive).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # To add a new machine configuration, do something similar to the following:
 #
 # matrix:


### PR DESCRIPTION
This pull request introduces a workflow improvement to the `.github/workflows/build.yml` file. The main change is the addition of a concurrency group to ensure that only the latest workflow run is active for a given branch or pull request, which helps reduce unnecessary resource usage during expensive Yocto builds.

Workflow optimization:

* Added a `concurrency` group to the workflow configuration to automatically cancel in-progress runs when new commits are pushed to the same branch or pull request, preventing redundant builds and saving resources.