### PR TITLE
Fix bdf2psf S path for wrynose UNPACKDIR

### DIFF
--- a/meta-calculinux-distro/recipes-core/fonts/bdf2psf_1.249.bb
+++ b/meta-calculinux-distro/recipes-core/fonts/bdf2psf_1.249.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://debian/copyright;md5=6fdba635ca4be614fab872320fcb2220
 SRC_URI = "${DEBIAN_MIRROR}/main/c/console-setup/console-setup_${PV}.tar.xz"
 SRC_URI[sha256sum] = "2042e268b085ad900f2f9863715d67fadb95b8994554f10d407fc14f224b73ae"
 
-S = "${WORKDIR}/console-setup"
+S = "${UNPACKDIR}/console-setup"
 
 inherit allarch
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Merging main into wrynose brought back `S = "${WORKDIR}/console-setup"` from the Debian-pool `bdf2psf` fix.
- Wrynose requires `S` under `UNPACKDIR`; CI fails at `bdf2psf-native` `do_unpack` with that exact guidance.
- Restore the wrynose unpack path while keeping the Debian pool `SRC_URI` (avoids salsa `git ls-remote` 503s).

## Test plan
- [ ] Wrynose CI parses and unpacks `bdf2psf-native` without the WORKDIR/UNPACKDIR error
- [ ] Build progresses past `bdf2psf` into real image work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce978916-200f-4be9-a1ff-3ed2884983c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce978916-200f-4be9-a1ff-3ed2884983c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

