### PR TITLE
Build vim without X11 so it starts after memory cuts

### DIFF
--- a/meta-calculinux-apps/recipes-core/packagegroups/packagegroup-meta-calculinux-apps.bb
+++ b/meta-calculinux-apps/recipes-core/packagegroups/packagegroup-meta-calculinux-apps.bb
@@ -5,8 +5,8 @@ LICENSE = "MIT"
 
 inherit packagegroup
 
-# Disable GTK GUI and sound for vim so we don't pull in an entire desktop stack
-PACKAGECONFIG:remove:pn-vim = "gtkgui sound"
+# Terminal vim only (see distro.conf). x11 must stay off with DISTRO_FEATURES.
+PACKAGECONFIG:remove:pn-vim = "gtkgui sound x11"
 
 PACKAGES = "${PN}"
 

--- a/meta-calculinux-distro/conf/distro/calculinux-distro.conf
+++ b/meta-calculinux-distro/conf/distro/calculinux-distro.conf
@@ -112,8 +112,9 @@ RDEPENDS:${PN}-mtrace:pn-eglibc = ""
 # Disable python usage in opkg-utils since it won't build with tiny config
 PACKAGECONFIG:remove:pn-opkg-utils = "python"
 
-# Disable GTK GUI and sound for vim so we don't pull in an entire desktop stack
-PACKAGECONFIG:remove:pn-vim = "gtkgui sound"
+# Terminal vim only — DISTRO_FEATURES drops x11, so a leftover --with-x
+# binary dies with "Error relocating /usr/bin/vim" (missing libX11.so.6).
+PACKAGECONFIG:remove:pn-vim = "gtkgui sound x11"
 
 # Enable wifi for connman
 # PACKAGECONFIG:pn-connman = "wispr client nftables wifi wpa-supplicant iwd"


### PR DESCRIPTION
## Summary
- `DISTRO_FEATURES` no longer includes `x11`, so the image dropped `libX11.so.6`.
- Installed vim was still linked `--with-x` and fails with `Error relocating /usr/bin/vim`.
- Remove `x11` from vim `PACKAGECONFIG` so the rebuild is terminal-only.

## Test plan
- [ ] Full image rebuild after this lands (expected: vim rebuilt `--without-x`)
- [ ] On device: `vim -u NONE -c q` starts without relocating errors
- [ ] `readelf -d /usr/bin/vim | grep NEEDED` has no `libX11` / `libXt`


Made with [Cursor](https://cursor.com)